### PR TITLE
fix: prevent iOS input zoom and fix footer safe-area overlap (SE-8)

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/src/lib/components/PlayerRow.svelte
+++ b/src/lib/components/PlayerRow.svelte
@@ -82,7 +82,7 @@
           onclick={(e) => e.stopPropagation()}
           onblur={submitRename}
           onkeydown={(e) => { if (e.key === 'Enter') submitRename(); }}
-          class="bg-gray-800 border border-blue-500 rounded px-2 py-0.5 text-sm w-full focus:outline-none"
+          class="bg-gray-800 border border-blue-500 rounded px-2 py-0.5 text-base w-full focus:outline-none"
           autofocus
         />
       {:else}

--- a/src/lib/components/ScoreInput.svelte
+++ b/src/lib/components/ScoreInput.svelte
@@ -40,7 +40,7 @@
     placeholder="Score"
     bind:value={inputValue}
     onfocus={(e) => (e.target as HTMLInputElement).select()}
-    class="w-24 bg-gray-800 border border-gray-600 focus:border-blue-500 rounded-lg px-3 py-2 text-sm text-center tabular-nums focus:outline-none"
+    class="w-24 bg-gray-800 border border-gray-600 focus:border-blue-500 rounded-lg px-3 py-2 text-base text-center tabular-nums focus:outline-none"
   />
 
   <button

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -77,7 +77,7 @@
   </main>
 
   <!-- Footer controls -->
-  <footer class="px-4 py-3 border-t border-gray-800 flex flex-col gap-2">
+  <footer class="px-4 pt-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] border-t border-gray-800 flex flex-col gap-2">
     {#if game.players.length < 12}
       <form
         onsubmit={(e) => { e.preventDefault(); handleAddPlayer(); }}
@@ -88,7 +88,7 @@
           placeholder="Player name"
           bind:value={newPlayerName}
           maxlength={20}
-          class="flex-1 bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-blue-500"
+          class="flex-1 bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-base focus:outline-none focus:border-blue-500"
         />
         <button
           type="submit"


### PR DESCRIPTION
## Summary

- Adds `viewport-fit=cover` to `app.html` to enable `env(safe-area-inset-*)` CSS values on iPhone
- Footer padding now uses `max(0.75rem, env(safe-area-inset-bottom))` so "Add Player" and "End Round" controls sit above the home indicator bar
- All three `<input>` elements bumped from `text-sm` (14px) to `text-base` (16px) to suppress iOS Safari's auto-zoom on focus

## Test plan

- [ ] Open on iPhone Safari (or DevTools responsive with iPhone preset + device frame)
- [ ] Tap each input — screen should **not** zoom
- [ ] Confirm footer controls are fully visible above the home indicator
- [ ] Verify no visual regression on desktop / Android
- [ ] `npm run check` — 0 errors
- [ ] `npm run lint` — no new errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)