### PR TITLE
fix: prevent page body scroll — constrain to viewport height (SE-12)

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -44,7 +44,7 @@
   );
 </script>
 
-<div class="min-h-screen bg-gray-950 text-white flex flex-col max-w-lg mx-auto">
+<div class="h-dvh bg-gray-950 text-white flex flex-col max-w-lg mx-auto">
   <!-- Header -->
   <header class="flex items-center justify-between px-4 py-3 border-b border-gray-800">
     <h1 class="text-xl font-bold tracking-tight">Flip 7</h1>


### PR DESCRIPTION
## Summary

- Replaces `min-h-screen` with `h-dvh` on the outer container so the app is exactly one viewport tall with no body scroll
- Header and footer are already sticky via flexbox — no further changes needed
- Only the player list (`flex-1 overflow-y-auto`) scrolls within the remaining space

Fixes #12

## Test plan

- [ ] Open app on mobile — page should not scroll; only the player list should scroll when there are enough players
- [ ] Header (title + New Game button) stays fixed at the top
- [ ] Footer (add player form + End Round button) stays fixed at the bottom
- [ ] All 16 unit tests pass (`npm run test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)