### PR TITLE
fix: disable double-tap zoom on mobile (SE-14)

### DIFF
--- a/src/routes/layout.css
+++ b/src/routes/layout.css
@@ -2,4 +2,5 @@
 
 body {
   @apply bg-gray-950;
+  touch-action: manipulation;
 }


### PR DESCRIPTION
## Summary

- Adds `touch-action: manipulation` to `body` in `layout.css`
- Prevents double-tap zoom on mobile browsers without disabling pinch-to-zoom (preserves accessibility)

Closes #14

## Test plan

- [ ] Open app on a mobile device or browser devtools mobile emulation
- [ ] Double-tap various buttons/cards — confirm no zoom occurs
- [ ] Confirm pinch-to-zoom still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)