### PR TITLE
fix: add page title to browser tab (SE-9)

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -5,5 +5,8 @@
 	let { children } = $props();
 </script>
 
-<svelte:head><link rel="icon" href={favicon} /></svelte:head>
+<svelte:head>
+	<title>Flip 7</title>
+	<link rel="icon" href={favicon} />
+</svelte:head>
 {@render children()}


### PR DESCRIPTION
## Summary

- Adds `<title>Flip 7</title>` to the layout `<svelte:head>` so the browser tab and history show a meaningful name

Closes #9

## Test plan

- [ ] Open the app in a browser — confirm tab shows "Flip 7"
- [ ] Check browser history entry shows "Flip 7"

🤖 Generated with [Claude Code](https://claude.com/claude-code)