### PR TITLE
fix: score history should exclude the most recent round (SE-18)

### DIFF
--- a/src/lib/components/PlayerRow.svelte
+++ b/src/lib/components/PlayerRow.svelte
@@ -25,7 +25,7 @@
 
   // Cumulative totals at the end of each previous round
   const cumulativeHistory = $derived(
-    scores.slice(0, currentRound).map((_, i) =>
+    scores.slice(0, Math.max(0, currentRound - 1)).map((_, i) =>
       scores.slice(0, i + 1).reduce<number>((sum, s) => sum + (s ?? 0), 0)
     )
   );


### PR DESCRIPTION
## Summary

- `cumulativeHistory` was slicing scores up to `currentRound`, incorrectly including the just-completed round in the history chips
- Fixed by slicing to `Math.max(0, currentRound - 1)` so history only shows rounds *before* the most recent — the current cumulative total already represents the latest round

**Before / after:**

| State | Cumulative | History (before) | History (after) |
|---|---|---|---|
| End of round 1 (scored n) | n | [n] ❌ | [] ✓ |
| End of round 2 (scored m) | n+m | [n, n+m] ❌ | [n] ✓ |

Closes #18

## Test plan

- [ ] Play a game: end round 1 — confirm no history chips appear
- [ ] End round 2 — confirm one chip showing round 1 cumulative appears
- [ ] End round 3 — confirm two chips showing round 1 and round 2 cumulatives

🤖 Generated with [Claude Code](https://claude.com/claude-code)