### PR TITLE
fix: resolve all Svelte a11y and reactivity warnings (SE-22)

### DIFF
--- a/src/lib/components/CardCalculator.svelte
+++ b/src/lib/components/CardCalculator.svelte
@@ -63,7 +63,7 @@
 </script>
 
 <!-- Fixed overlay backdrop — tap outside to dismiss -->
-<div transition:fade={{ duration: 250 }} class="fixed inset-0 z-40 bg-black/50" onclick={onDismiss}></div>
+<div transition:fade={{ duration: 250 }} class="fixed inset-0 z-40 bg-black/50" role="presentation" onclick={onDismiss} onkeydown={(e) => e.key === 'Escape' && onDismiss()}></div>
 
 <!-- Bottom sheet panel -->
 <div

--- a/src/lib/components/PlayerRow.svelte
+++ b/src/lib/components/PlayerRow.svelte
@@ -2,6 +2,7 @@
   import type { Player } from '$lib/types';
   import { removePlayer, renamePlayer } from '$lib/game.svelte';
   import ScoreInput from './ScoreInput.svelte';
+  import { untrack } from 'svelte';
 
   let {
     player,
@@ -21,7 +22,7 @@
 
   let showActions = $state(false);
   let isRenaming = $state(false);
-  let renameValue = $state(player.name);
+  let renameValue = $state(untrack(() => player.name));
 
   // Cumulative totals at the end of each previous round
   const cumulativeHistory = $derived(
@@ -76,6 +77,7 @@
     <div class="flex-1 min-w-0">
       {#if isRenaming}
         <!-- svelte-ignore event_directive_deprecated -->
+        <!-- svelte-ignore a11y_autofocus -->
         <input
           type="text"
           bind:value={renameValue}
@@ -129,12 +131,16 @@
   <div
     class="fixed inset-0 bg-black/60 z-10 flex items-end"
     onclick={() => (showActions = false)}
+    onkeydown={(e) => e.key === 'Escape' && (showActions = false)}
     role="dialog"
     aria-modal="true"
+    tabindex="-1"
   >
     <div
       class="w-full bg-gray-900 rounded-t-2xl p-4"
+      role="none"
       onclick={(e) => e.stopPropagation()}
+      onkeydown={(e) => e.stopPropagation()}
     >
       <p class="text-center text-sm font-semibold text-gray-300 mb-3">{player.name}</p>
       <button

--- a/src/lib/components/ScoreInput.svelte
+++ b/src/lib/components/ScoreInput.svelte
@@ -2,6 +2,7 @@
   import type { Player } from '$lib/types';
   import { setScore } from '$lib/game.svelte';
   import CardCalculator from './CardCalculator.svelte';
+  import { untrack } from 'svelte';
 
   let {
     player,
@@ -14,7 +15,7 @@
   } = $props();
 
   // Pre-populate with existing score if present
-  let inputValue = $state(currentRoundScore !== null ? String(currentRoundScore) : '');
+  let inputValue = $state(untrack(() => currentRoundScore !== null ? String(currentRoundScore) : ''));
   let calculatorOpen = $state(false);
 
   function handleSave() {


### PR DESCRIPTION
## Summary
- Add `role="presentation"` + keyboard handler to `CardCalculator` backdrop div
- Wrap `$state` initialisers with `untrack()` in `ScoreInput` and `PlayerRow` to make intent explicit
- Add `tabindex`, keyboard handler, and correct ARIA roles to `PlayerRow` actions overlay
- Suppress intentional `autofocus` with `svelte-ignore` comment

## Test Plan
- [x] `npm run check` — 0 errors, 0 warnings
- [x] `npm run test` — 16/16 tests pass