### PR TITLE
feat: flip 7 detection in calculator with round-end banner (SE-26)

### DIFF
--- a/src/lib/components/CardCalculator.svelte
+++ b/src/lib/components/CardCalculator.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { calcCardTotal } from '$lib/gameLogic';
+  import { calcCardTotal, FLIP_7_CARD_COUNT, FLIP_7_BONUS } from '$lib/gameLogic';
   import { fly, fade } from 'svelte/transition';
   import { cubicOut, cubicIn } from 'svelte/easing';
 
@@ -8,7 +8,7 @@
     onBust,
     onDismiss,
   }: {
-    onApply: (total: number) => void;
+    onApply: (total: number, isFlip7: boolean) => void;
     onBust: () => void;
     onDismiss: () => void;
   } = $props();
@@ -33,8 +33,11 @@
       : [...selectedModifiers, m];
   }
 
+  // --- Flip 7 detection ---
+  const isFlip7 = $derived(selectedNumbers.length === FLIP_7_CARD_COUNT);
+
   // --- Derived total ---
-  let total = $derived(calcCardTotal(selectedNumbers, selectedModifiers, x2Selected));
+  let total = $derived(calcCardTotal(selectedNumbers, selectedModifiers, x2Selected) + (isFlip7 ? FLIP_7_BONUS : 0));
 
   // --- Formula breakdown string ---
   // Formula mirrors calcCardTotal — keep in sync if scoring rules change.
@@ -58,7 +61,9 @@
           ? ` + ${modSum}`
           : `+${modSum}`;
 
-    return `${numberPart}${multiplierPart}${modifierPart}`;
+    const flip7Part = isFlip7 ? ` + ${FLIP_7_BONUS} (Flip 7!)` : '';
+
+    return `${numberPart}${multiplierPart}${modifierPart}${flip7Part}`;
   });
 </script>
 
@@ -102,14 +107,22 @@
     </button>
   </div>
 
+  <!-- Flip 7 badge -->
+  {#if isFlip7}
+    <div class="flex items-center gap-2 mb-3 px-3 py-2 bg-amber-400/10 border border-amber-400/40 rounded-xl">
+      <span class="text-amber-400 font-bold text-sm">🎴 Flip 7! +15 bonus applied</span>
+    </div>
+  {/if}
+
   <!-- Number cards -->
   <p class="text-xs font-semibold uppercase tracking-wider text-gray-500 mb-2">Number Cards</p>
   <div class="flex flex-wrap gap-2 mb-4">
-    {#each NUMBER_CARDS as n}
+    {#each NUMBER_CARDS as n (n)}
       <button
         type="button"
         onclick={() => toggleNumber(n)}
-        class="rounded-full px-3 py-1.5 text-sm font-medium border transition-colors
+        disabled={isFlip7 && !selectedNumbers.includes(n)}
+        class="rounded-full px-3 py-1.5 text-sm font-medium border transition-colors disabled:opacity-30 disabled:cursor-not-allowed
           {selectedNumbers.includes(n)
             ? 'bg-amber-400 text-gray-900 border-amber-400'
             : 'bg-transparent text-gray-400 border-gray-600 hover:border-gray-400'}"
@@ -122,7 +135,7 @@
   <!-- Modifier cards -->
   <p class="text-xs font-semibold uppercase tracking-wider text-gray-500 mb-2">Modifier Cards</p>
   <div class="flex flex-wrap gap-2 mb-4">
-    {#each MODIFIER_CARDS as m}
+    {#each MODIFIER_CARDS as m (m)}
       <button
         type="button"
         onclick={() => toggleModifier(m)}
@@ -154,7 +167,7 @@
   <!-- Apply button -->
   <button
     type="button"
-    onclick={() => onApply(total)}
+    onclick={() => onApply(total, isFlip7)}
     class="w-full rounded-xl bg-amber-400 text-gray-900 font-bold py-3 text-base hover:bg-amber-300 transition-colors"
   >
     Apply {total}

--- a/src/lib/components/PlayerRow.svelte
+++ b/src/lib/components/PlayerRow.svelte
@@ -76,7 +76,6 @@
     <!-- Player name + history -->
     <div class="flex-1 min-w-0">
       {#if isRenaming}
-        <!-- svelte-ignore event_directive_deprecated -->
         <!-- svelte-ignore a11y_autofocus -->
         <input
           type="text"

--- a/src/lib/components/ScoreInput.svelte
+++ b/src/lib/components/ScoreInput.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { Player } from '$lib/types';
-  import { setScore } from '$lib/game.svelte';
+  import { setScore, setFlip7Banner } from '$lib/game.svelte';
   import CardCalculator from './CardCalculator.svelte';
   import { untrack } from 'svelte';
 
@@ -17,13 +17,31 @@
   // Pre-populate with existing score if present
   let inputValue = $state(untrack(() => currentRoundScore !== null ? String(currentRoundScore) : ''));
   let calculatorOpen = $state(false);
+  let pendingFlip7Score = $state<number | null>(null);
+  let showFlip7Confirm = $state(false);
 
   function handleSave() {
     const parsed = parseInt(inputValue, 10);
-    if (!isNaN(parsed) && parsed >= 0) {
-      setScore(player.id, parsed);
-      onSave();
+    if (isNaN(parsed) || parsed < 0) return;
+    if (pendingFlip7Score !== null) {
+      showFlip7Confirm = true;
+      return;
     }
+    commitSave(parsed);
+  }
+
+  function commitSave(score: number) {
+    setScore(player.id, score);
+    onSave();
+  }
+
+  function confirmFlip7Save() {
+    if (pendingFlip7Score === null) return;
+    setScore(player.id, pendingFlip7Score);
+    setFlip7Banner(true);
+    pendingFlip7Score = null;
+    showFlip7Confirm = false;
+    onSave();
   }
 
   function handleBust() {
@@ -70,9 +88,10 @@
 
 {#if calculatorOpen}
   <CardCalculator
-    onApply={(total) => {
+    onApply={(total, isFlip7) => {
       inputValue = String(total);
       calculatorOpen = false;
+      pendingFlip7Score = isFlip7 ? total : null;
     }}
     onBust={() => {
       handleBust();
@@ -80,6 +99,31 @@
     }}
     onDismiss={() => (calculatorOpen = false)}
   />
+{/if}
+
+{#if showFlip7Confirm}
+  <div class="fixed inset-0 bg-black/70 flex items-center justify-center z-30 px-6">
+    <div class="bg-gray-900 rounded-2xl p-6 w-full max-w-sm text-white">
+      <p class="text-center text-lg font-semibold mb-1">🎴 Flip 7!</p>
+      <p class="text-center text-sm text-gray-400 mb-5">
+        Saving this score ends your turn for this round. Other players still need to enter their scores.
+      </p>
+      <div class="flex gap-3">
+        <button
+          onclick={() => { showFlip7Confirm = false; }}
+          class="flex-1 py-2 rounded-lg bg-gray-700 hover:bg-gray-600 text-sm font-medium transition-colors"
+        >
+          Cancel
+        </button>
+        <button
+          onclick={confirmFlip7Save}
+          class="flex-1 py-2 rounded-lg bg-amber-500 hover:bg-amber-400 text-gray-900 text-sm font-semibold transition-colors"
+        >
+          Save Score
+        </button>
+      </div>
+    </div>
+  </div>
 {/if}
 
 <style>

--- a/src/lib/game.svelte.ts
+++ b/src/lib/game.svelte.ts
@@ -1,6 +1,6 @@
 import { browser } from '$app/environment';
 import { createEmptyGame, totalScore, getWinners } from './gameLogic';
-import type { GameState, Player } from './types';
+import type { GameState } from './types';
 
 const STORAGE_KEY = 'flip7_game';
 
@@ -70,6 +70,13 @@ export function setScore(playerId: string, score: number): void {
   persist();
 }
 
+// Flip 7 banner — true when a player has flipped 7 this round
+export const flip7Banner = $state({ active: false });
+
+export function setFlip7Banner(val: boolean): void {
+  flip7Banner.active = val;
+}
+
 export function endRound(): void {
   // Fill any missing scores with 0 before advancing
   for (const player of game.players) {
@@ -79,6 +86,7 @@ export function endRound(): void {
       setScore(player.id, 0);
     }
   }
+  flip7Banner.active = false;
   game.currentRound += 1;
   persist();
 }
@@ -88,6 +96,7 @@ export function newGame(): void {
   game.players = empty.players;
   game.scores = empty.scores;
   game.currentRound = empty.currentRound;
+  flip7Banner.active = false;
   if (browser) {
     localStorage.removeItem(STORAGE_KEY);
   }

--- a/src/lib/gameLogic.test.ts
+++ b/src/lib/gameLogic.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { totalScore, getWinners, createEmptyGame, calcCardTotal } from './gameLogic';
+import { totalScore, getWinners, createEmptyGame, calcCardTotal, FLIP_7_CARD_COUNT, FLIP_7_BONUS } from './gameLogic';
 import type { GameState } from './types';
 
 describe('totalScore', () => {
@@ -111,6 +111,15 @@ describe('createEmptyGame', () => {
     expect(game.players).toEqual([]);
     expect(game.scores).toEqual({});
     expect(game.currentRound).toBe(0);
+  });
+});
+
+describe('Flip 7 constants', () => {
+  it('FLIP_7_CARD_COUNT is 7', () => {
+    expect(FLIP_7_CARD_COUNT).toBe(7);
+  });
+  it('FLIP_7_BONUS is 15', () => {
+    expect(FLIP_7_BONUS).toBe(15);
   });
 });
 

--- a/src/lib/gameLogic.ts
+++ b/src/lib/gameLogic.ts
@@ -1,5 +1,8 @@
 import type { GameState, Player } from './types';
 
+export const FLIP_7_CARD_COUNT = 7;
+export const FLIP_7_BONUS = 15;
+
 /** Sum of all non-null scores for a player. */
 export function totalScore(
   scores: Record<string, (number | null)[]>,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { game, addPlayer, endRound, newGame, getWinners, totalScore } from '$lib/game.svelte';
+  import { game, addPlayer, endRound, newGame, getWinners, totalScore, flip7Banner } from '$lib/game.svelte';
   import PlayerRow from '$lib/components/PlayerRow.svelte';
 
   // Which player row is currently expanded (null = none)
@@ -55,6 +55,13 @@
       New Game
     </button>
   </header>
+
+  <!-- Flip 7 banner -->
+  {#if flip7Banner.active}
+    <div class="px-4 py-2 bg-amber-400/10 border-b border-amber-400/30 text-amber-300 text-xs text-center">
+      🎴 Someone flipped 7 — enter your scores and hit <strong>End Round</strong>
+    </div>
+  {/if}
 
   <!-- Player list -->
   <main class="flex-1 overflow-y-auto px-4 py-2">


### PR DESCRIPTION
## Summary
- Selecting all 7 number cards in the calculator now triggers "Flip 7": number card buttons are disabled, +15 bonus is applied to the total, and a badge confirms the bonus
- Saving a Flip 7 score shows a confirmation dialog warning the player that their turn ends
- After confirming, a sticky banner appears below the header reminding other players to enter their scores and end the round
- Banner clears automatically when End Round is pressed
- Also removes a stale `svelte-ignore` comment in `PlayerRow.svelte` that was causing a lint error

## Test Plan
- [ ] Open calculator, select 7 number cards — confirm remaining number buttons are disabled, +15 badge appears, total includes the bonus
- [ ] Tap Apply with 7 cards — confirm score populates, then tap Save — confirm the Flip 7 confirmation dialog appears
- [ ] Cancel the dialog — confirm score input remains editable
- [ ] Confirm the save — confirm sticky amber banner appears below the header
- [ ] Have another player enter their score and tap End Round — confirm banner disappears
- [ ] Deselect a card (back to 6) before applying — confirm no Flip 7 dialog on save