### PR TITLE
fix: show bust (zero) round score in red

### DIFF
--- a/src/lib/components/PlayerRow.svelte
+++ b/src/lib/components/PlayerRow.svelte
@@ -102,8 +102,8 @@
       {/if}
     </div>
 
-    <!-- Current round score (blue when saved, -- when pending) -->
-    <span class="text-sm tabular-nums w-10 text-center {currentRoundScore !== null ? 'text-blue-400 font-semibold' : 'text-gray-400'}">
+    <!-- Current round score (red for bust, blue when saved, -- when pending) -->
+    <span class="text-sm tabular-nums w-10 text-center {currentRoundScore === null ? 'text-gray-400' : currentRoundScore === 0 ? 'text-red-400 font-semibold' : 'text-blue-400 font-semibold'}">
       {currentRoundScore !== null ? currentRoundScore : '--'}
     </span>
 


### PR DESCRIPTION
## Summary
- Bust scores (0) now display in red (`text-red-400`) instead of blue
- Non-zero saved scores remain blue
- Unsaved rounds still show `--` in gray

> **Note:** depends on #41 — merge that first.

## Colour logic
| State | Display | Colour |
|-------|---------|--------|
| Not saved | `--` | Gray |
| Saved, score = 0 (Bust) | `0` | Red |
| Saved, score > 0 | score | Blue |

## Test Plan
- [ ] Enter a normal score → displays in blue
- [ ] Enter a Bust → displays `0` in red
- [ ] Player with no score entered shows `--` in gray
- [ ] `npm run test` passes with no regressions