### PR TITLE
feat: warn when ending round with unscored players

### DIFF
--- a/docs/superpowers/plans/2026-03-17-unscored-player-warning.md
+++ b/docs/superpowers/plans/2026-03-17-unscored-player-warning.md
@@ -1,0 +1,260 @@
+# Unscored Player Warning Dialog Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show a confirmation dialog when the user clicks "End Round" if any players have no score entered, listing those players by name.
+
+**Architecture:** All changes are confined to `src/routes/+page.svelte`. Add a `showBustWarning` state boolean, an `unscoredPlayers` derived, intercept the End Round click to show the dialog when needed, and add an inline dialog block matching the existing "New Game" confirm pattern.
+
+**Tech Stack:** SvelteKit 2, Svelte 5 runes (`$state`, `$derived`), TypeScript, Tailwind CSS v4
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `src/routes/+page.svelte` | Add state, derived, handlers, and dialog markup |
+
+---
+
+### Task 1: Create feature branch
+
+- [ ] **Step 1: Create and switch to feature branch**
+
+```bash
+git checkout -b feat/unscored-player-warning
+```
+
+Expected: `Switched to a new branch 'feat/unscored-player-warning'`
+
+---
+
+### Task 2: Add state and derived to `+page.svelte`
+
+**Files:**
+- Modify: `src/routes/+page.svelte` (script block, lines 1–49)
+
+- [ ] **Step 1: Add `showBustWarning` state**
+
+In the `<script>` block, after the existing `let showHelp = $state(false);` line (currently line 16), add:
+
+```ts
+// Show bust warning dialog when some players have no score
+let showBustWarning = $state(false);
+```
+
+- [ ] **Step 2: Add `unscoredPlayers` derived**
+
+After the existing `canEndRound` derived (currently ends around line 48), add:
+
+```ts
+// Players with no score entered for the current round
+const unscoredPlayers = $derived(
+  game.players.filter((p) => {
+    const s = game.scores[p.id];
+    return s[game.currentRound] === undefined || s[game.currentRound] === null;
+  })
+);
+```
+
+> `s` is always a defined array (initialised to `[]` in `addPlayer`). Entries are `null` when back-filled by `setScore`; `undefined` when the array has never been extended to this round index. Both indicate "no score entered".
+
+- [ ] **Step 3: Run type check to verify no errors**
+
+```bash
+npm run check
+```
+
+Expected: No errors.
+
+---
+
+### Task 3: Update `handleEndRound` and add `confirmEndRound`
+
+**Files:**
+- Modify: `src/routes/+page.svelte` (script block, `handleEndRound` function)
+
+- [ ] **Step 1: Update `handleEndRound` to show warning when needed**
+
+Replace the existing `handleEndRound` function:
+
+```ts
+function handleEndRound() {
+  endRound();
+  const w = getWinners(game);
+  if (w) winners = w;
+}
+```
+
+With:
+
+```ts
+function handleEndRound() {
+  if (unscoredPlayers.length > 0) {
+    showBustWarning = true;
+    return;
+  }
+  endRound();
+  const w = getWinners(game);
+  if (w) winners = w;
+}
+```
+
+- [ ] **Step 2: Add `confirmEndRound` handler below `handleEndRound`**
+
+```ts
+function confirmEndRound() {
+  showBustWarning = false;
+  endRound();
+  const w = getWinners(game);
+  if (w) winners = w;
+}
+```
+
+> Dialog is dismissed before checking for winners so the bust warning is never visible beneath the winner banner.
+
+- [ ] **Step 3: Run type check**
+
+```bash
+npm run check
+```
+
+Expected: No errors.
+
+---
+
+### Task 4: Add the warning dialog markup
+
+**Files:**
+- Modify: `src/routes/+page.svelte` (template, after the New Game confirm dialog block)
+
+- [ ] **Step 1: Add dialog block after the New Game confirmation dialog**
+
+The New Game dialog ends around line 175 with `{/if}`. Immediately after it, add:
+
+```svelte
+<!-- Bust warning dialog -->
+{#if showBustWarning}
+  <div class="fixed inset-0 bg-black/70 flex items-center justify-center z-10 px-6">
+    <div class="bg-gray-900 rounded-2xl p-6 w-full max-w-sm text-white">
+      <p class="text-center text-lg font-semibold mb-1">Some players haven't scored</p>
+      <p class="text-center text-sm text-gray-400 mb-3">These players will be marked as bust (0):</p>
+      <ul class="text-center text-sm text-white mb-5 space-y-1">
+        {#each unscoredPlayers as player (player.id)}
+          <li>{player.name}</li>
+        {/each}
+      </ul>
+      <div class="flex gap-3">
+        <button
+          onclick={() => (showBustWarning = false)}
+          class="flex-1 py-2 rounded-lg bg-gray-700 hover:bg-gray-600 text-sm font-medium transition-colors"
+        >
+          Cancel
+        </button>
+        <button
+          onclick={confirmEndRound}
+          class="flex-1 py-2 rounded-lg bg-emerald-700 hover:bg-emerald-600 text-sm font-medium transition-colors"
+        >
+          End Round
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}
+```
+
+- [ ] **Step 2: Run type check**
+
+```bash
+npm run check
+```
+
+Expected: No errors.
+
+- [ ] **Step 3: Run lint**
+
+```bash
+npm run lint
+```
+
+Expected: No errors.
+
+---
+
+### Task 5: Manual verification
+
+- [ ] **Step 1: Start the dev server**
+
+```bash
+npm run dev
+```
+
+- [ ] **Step 2: Verify — all players scored, no dialog**
+
+Add 2 players. Enter a score for both. Click "End Round". Expected: round advances immediately with no dialog.
+
+- [ ] **Step 3: Verify — one player unscored, dialog appears**
+
+Add 2 players. Enter a score for player 1 only. Click "End Round". Expected: warning dialog appears listing player 2's name.
+
+- [ ] **Step 4: Verify — Cancel dismisses without ending round**
+
+With the dialog open, click Cancel. Expected: dialog closes, still on the same round, no scores changed.
+
+- [ ] **Step 5: Verify — End Round in dialog proceeds**
+
+With the dialog open, click End Round. Expected: dialog closes, round advances, unscored player shows 0 (bust in red) for that round.
+
+- [ ] **Step 6: Verify — all players unscored, button is disabled**
+
+Add 2 players. Do not enter any scores. Expected: "End Round" button is disabled (greyed out) — dialog is never reachable.
+
+- [ ] **Step 7: Stop the dev server**
+
+`Ctrl+C`
+
+---
+
+### Task 6: Commit
+
+- [ ] **Step 1: Stage and commit**
+
+```bash
+git add src/routes/+page.svelte
+git commit -m "feat: warn when ending round with unscored players"
+```
+
+---
+
+### Task 7: Create PR
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push -u origin feat/unscored-player-warning
+```
+
+- [ ] **Step 2: Create PR via MCP GitHub tool**
+
+Use `mcp__plugin_github_github__create_pull_request` with:
+- `owner`: (repo owner)
+- `repo`: `flip7scorecard`
+- `title`: `feat: warn when ending round with unscored players`
+- `head`: `feat/unscored-player-warning`
+- `base`: `master`
+- `body`:
+
+```
+## Summary
+- Shows a confirmation dialog when "End Round" is clicked and some players have no score for the current round
+- Dialog lists the unscored player names and states they will be marked as bust
+- Cancel dismisses without ending the round; End Round proceeds as normal
+
+## Test plan
+- [ ] All players scored → End Round proceeds immediately, no dialog
+- [ ] One or more players unscored → warning dialog appears with their names
+- [ ] Cancel in dialog → dialog dismisses, round not ended
+- [ ] End Round in dialog → round advances, unscored players get 0 (bust)
+- [ ] Zero players scored → End Round button is disabled, dialog unreachable
+```

--- a/docs/superpowers/specs/2026-03-17-unscored-player-warning-design.md
+++ b/docs/superpowers/specs/2026-03-17-unscored-player-warning-design.md
@@ -1,7 +1,7 @@
 # Design: Unscored Player Warning Dialog
 
 **Date:** 2026-03-17
-**Status:** Approved
+**Status:** Draft
 
 ## Problem
 
@@ -15,7 +15,7 @@ Intercept the End Round action and show a confirmation dialog when one or more p
 
 ### Approach
 
-Option A — inline dialog in `+page.svelte`, consistent with the existing "New Game" confirmation pattern. No new files or components.
+Option A — inline dialog in `src/routes/+page.svelte`, consistent with the existing "New Game" confirmation pattern. No new files or components.
 
 ### Changes (all in `src/routes/+page.svelte`)
 
@@ -29,22 +29,28 @@ let showBustWarning = $state(false);
 const unscoredPlayers = $derived(
   game.players.filter((p) => {
     const s = game.scores[p.id];
-    return !s || s[game.currentRound] === undefined || s[game.currentRound] === null;
+    return s[game.currentRound] === undefined || s[game.currentRound] === null;
   })
 );
 ```
+
+> Note: `game.scores[p.id]` is always initialised to `[]` in `addPlayer`, so `s` is always a defined array. An entry is `null` when `setScore` back-filled a shorter array (explicit null placeholder). An entry is `undefined` when the array has never been extended to that round index. Both must be checked.
 
 **Modified `handleEndRound`:**
 - If `unscoredPlayers.length > 0`, set `showBustWarning = true` and return early
 - Otherwise call `endRound()` and check for winners as today
 
+> Note: `canEndRound` already disables the button when zero players have scored, so `handleEndRound` is only ever called when at least one player has a score. The "all players unscored" case is therefore unreachable here.
+
 **New `confirmEndRound` handler:**
-- Calls `endRound()`
-- Checks for winners
-- Sets `showBustWarning = false`
+1. Set `showBustWarning = false`
+2. Call `endRound()`
+3. Check for winners via `getWinners(game)` and set `winners` if found
+
+Dismissing the dialog before checking for winners ensures it is never visible beneath the winner banner.
 
 **New inline dialog (`{#if showBustWarning}`):**
-- Same visual style as the existing New Game confirm dialog (dark overlay, rounded card)
+- Same visual style as the existing New Game confirm dialog (dark overlay, `z-10`, rounded card)
 - Title: "Some players haven't scored"
 - Body: lists unscored player names; states they will be marked as bust
 - "Cancel" button: sets `showBustWarning = false`
@@ -60,7 +66,9 @@ const unscoredPlayers = $derived(
 
 | Scenario | Result |
 |----------|--------|
+| Zero players have scored | End Round button is disabled — dialog never shown |
 | All players scored | End Round proceeds immediately, no dialog |
-| One or more players unscored | Warning dialog shown with player names |
+| One or more players unscored | Warning dialog shown listing unscored player names |
 | User clicks Cancel | Dialog dismissed, round not ended |
-| User clicks End Round in dialog | Round ends, unscored players get bust (0) |
+| User clicks End Round in dialog | `showBustWarning` cleared, round ends, unscored players get bust (0) |
+| Round end via dialog causes a winner | Dialog dismissed first, then winner banner (z-20) appears on top |

--- a/docs/superpowers/specs/2026-03-17-unscored-player-warning-design.md
+++ b/docs/superpowers/specs/2026-03-17-unscored-player-warning-design.md
@@ -1,0 +1,66 @@
+# Design: Unscored Player Warning Dialog
+
+**Date:** 2026-03-17
+**Status:** Approved
+
+## Problem
+
+When a user clicks "End Round", any players without a score are silently treated as bust (score = 0). Users may not notice they've missed entering a score for a player.
+
+## Solution
+
+Intercept the End Round action and show a confirmation dialog when one or more players have no score for the current round. The user can proceed (accepting bust for those players) or cancel (to go back and enter scores).
+
+## Design
+
+### Approach
+
+Option A — inline dialog in `+page.svelte`, consistent with the existing "New Game" confirmation pattern. No new files or components.
+
+### Changes (all in `src/routes/+page.svelte`)
+
+**New state:**
+```ts
+let showBustWarning = $state(false);
+```
+
+**New derived:**
+```ts
+const unscoredPlayers = $derived(
+  game.players.filter((p) => {
+    const s = game.scores[p.id];
+    return !s || s[game.currentRound] === undefined || s[game.currentRound] === null;
+  })
+);
+```
+
+**Modified `handleEndRound`:**
+- If `unscoredPlayers.length > 0`, set `showBustWarning = true` and return early
+- Otherwise call `endRound()` and check for winners as today
+
+**New `confirmEndRound` handler:**
+- Calls `endRound()`
+- Checks for winners
+- Sets `showBustWarning = false`
+
+**New inline dialog (`{#if showBustWarning}`):**
+- Same visual style as the existing New Game confirm dialog (dark overlay, rounded card)
+- Title: "Some players haven't scored"
+- Body: lists unscored player names; states they will be marked as bust
+- "Cancel" button: sets `showBustWarning = false`
+- "End Round" button: calls `confirmEndRound`
+
+### No changes to
+
+- `src/lib/game.svelte.ts`
+- `src/lib/gameLogic.ts`
+- Any other component
+
+## Behaviour
+
+| Scenario | Result |
+|----------|--------|
+| All players scored | End Round proceeds immediately, no dialog |
+| One or more players unscored | Warning dialog shown with player names |
+| User clicks Cancel | Dialog dismissed, round not ended |
+| User clicks End Round in dialog | Round ends, unscored players get bust (0) |

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -15,6 +15,9 @@
   // Show help modal
   let showHelp = $state(false);
 
+  // Show bust warning dialog when some players have no score
+  let showBustWarning = $state(false);
+
   // Winner state — set after endRound detects 200+
   let winners = $state<import('$lib/types').Player[] | null>(null);
 
@@ -26,6 +29,17 @@
   }
 
   function handleEndRound() {
+    if (unscoredPlayers.length > 0) {
+      showBustWarning = true;
+      return;
+    }
+    endRound();
+    const w = getWinners(game);
+    if (w) winners = w;
+  }
+
+  function confirmEndRound() {
+    showBustWarning = false;
     endRound();
     const w = getWinners(game);
     if (w) winners = w;
@@ -45,6 +59,14 @@
         const s = game.scores[p.id];
         return s && s[game.currentRound] !== undefined && s[game.currentRound] !== null;
       })
+  );
+
+  // Players with no score entered for the current round
+  const unscoredPlayers = $derived(
+    game.players.filter((p) => {
+      const s = game.scores[p.id];
+      return !s || s[game.currentRound] === undefined || s[game.currentRound] === null;
+    })
   );
 </script>
 
@@ -168,6 +190,35 @@
           class="flex-1 py-2 rounded-lg bg-red-700 hover:bg-red-600 text-sm font-medium transition-colors"
         >
           New Game
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<!-- Bust warning dialog -->
+{#if showBustWarning}
+  <div class="fixed inset-0 bg-black/70 flex items-center justify-center z-10 px-6">
+    <div class="bg-gray-900 rounded-2xl p-6 w-full max-w-sm text-white">
+      <p class="text-center text-lg font-semibold mb-1">Some players haven't scored</p>
+      <p class="text-center text-sm text-gray-400 mb-3">These players will be marked as bust (0):</p>
+      <ul class="text-center text-sm text-white mb-5 space-y-1">
+        {#each unscoredPlayers as player (player.id)}
+          <li>{player.name}</li>
+        {/each}
+      </ul>
+      <div class="flex gap-3">
+        <button
+          onclick={() => (showBustWarning = false)}
+          class="flex-1 py-2 rounded-lg bg-gray-700 hover:bg-gray-600 text-sm font-medium transition-colors"
+        >
+          Cancel
+        </button>
+        <button
+          onclick={confirmEndRound}
+          class="flex-1 py-2 rounded-lg bg-emerald-700 hover:bg-emerald-600 text-sm font-medium transition-colors"
+        >
+          End Round
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Shows a confirmation dialog when "End Round" is clicked and some players have no score for the current round
- Dialog lists the unscored player names and states they will be marked as bust
- Cancel dismisses without ending the round; End Round proceeds as normal

## Test plan
- [ ] All players scored → End Round proceeds immediately, no dialog
- [ ] One or more players unscored → warning dialog appears with their names
- [ ] Cancel in dialog → dialog dismisses, round not ended
- [ ] End Round in dialog → round advances, unscored players get 0 (bust)
- [ ] Zero players scored → End Round button is disabled, dialog unreachable