### PR TITLE
feat: keep players when starting a new game from winner banner

### DIFF
--- a/docs/superpowers/plans/2026-03-17-persist-players-on-new-game.md
+++ b/docs/superpowers/plans/2026-03-17-persist-players-on-new-game.md
@@ -1,0 +1,212 @@
+# Persist Players on New Game Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep the player list when starting a new game from the winner banner, so players don't need to re-enter names for a rematch.
+
+**Architecture:** Add a `playAgain()` function to the game store that resets scores and round but preserves players. Update the winner banner in `+page.svelte` to call it. The header "New Game" button is untouched and still wipes everything.
+
+**Tech Stack:** SvelteKit 2, Svelte 5 runes, TypeScript
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `src/lib/game.svelte.ts` | Add exported `playAgain()` function |
+| `src/routes/+page.svelte` | Import `playAgain`, add `handlePlayAgain`, update winner banner button |
+
+---
+
+### Task 1: Create feature branch
+
+- [ ] **Step 1: Create and switch to feature branch**
+
+```bash
+git checkout -b feat/persist-players-on-new-game
+```
+
+Expected: `Switched to a new branch 'feat/persist-players-on-new-game'`
+
+---
+
+### Task 2: Add `playAgain()` to `game.svelte.ts`
+
+**Files:**
+- Modify: `src/lib/game.svelte.ts`
+
+> Note: `game.svelte.ts` uses Svelte 5 `$state` and cannot be unit-tested with Vitest directly. Verification is via type check and manual testing.
+
+- [ ] **Step 1: Add the `playAgain` function**
+
+Open `src/lib/game.svelte.ts`. After the `newGame()` function (currently ends around line 103), add:
+
+```ts
+export function playAgain(): void {
+  const freshScores: Record<string, (number | null)[]> = {};
+  for (const player of game.players) {
+    freshScores[player.id] = [];
+  }
+  game.scores = freshScores;
+  game.currentRound = 0;
+  flip7Banner.active = false;
+  persist();
+}
+```
+
+This rebuilds `game.scores` with an empty array per existing player, resets `currentRound` to 0, clears the Flip 7 banner, and persists the state. `game.players` is not touched. Unlike `newGame()` which calls `localStorage.removeItem()`, this calls `persist()` to save the player list.
+
+- [ ] **Step 2: Run type check**
+
+```bash
+npm run check
+```
+
+Expected: 0 errors, 0 warnings.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/game.svelte.ts
+git commit -m "feat: add playAgain to reset scores while keeping players"
+```
+
+---
+
+### Task 3: Update `+page.svelte` — handler and winner banner
+
+**Files:**
+- Modify: `src/routes/+page.svelte`
+
+- [ ] **Step 1: Import `playAgain`**
+
+Find the existing import on line 2:
+
+```ts
+import { game, addPlayer, endRound, newGame, getWinners, totalScore, flip7Banner } from '$lib/game.svelte';
+```
+
+Add `playAgain` to the import:
+
+```ts
+import { game, addPlayer, endRound, newGame, playAgain, getWinners, totalScore, flip7Banner } from '$lib/game.svelte';
+```
+
+- [ ] **Step 2: Add `handlePlayAgain` handler**
+
+After the existing `handleNewGame()` function (currently around line 34–39), add:
+
+```ts
+function handlePlayAgain() {
+  playAgain();
+  winners = null;
+  showNewGameConfirm = false;
+  expandedPlayerId = null;
+}
+```
+
+- [ ] **Step 3: Update the winner banner button**
+
+Find the winner banner button (currently around line 244):
+
+```svelte
+<button
+  onclick={handleNewGame}
+  class="w-full py-3 rounded-xl bg-blue-600 hover:bg-blue-500 font-semibold transition-colors"
+>
+  New Game
+</button>
+```
+
+Change it to:
+
+```svelte
+<button
+  onclick={handlePlayAgain}
+  class="w-full py-3 rounded-xl bg-blue-600 hover:bg-blue-500 font-semibold transition-colors"
+>
+  Play Again
+</button>
+```
+
+- [ ] **Step 4: Run type check**
+
+```bash
+npm run check
+```
+
+Expected: 0 errors, 0 warnings.
+
+- [ ] **Step 5: Run lint**
+
+```bash
+npm run lint
+```
+
+Expected: No errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/routes/+page.svelte
+git commit -m "feat: wire Play Again button to keep players on rematch"
+```
+
+---
+
+### Task 4: Manual verification
+
+- [ ] **Step 1: Start dev server**
+
+```bash
+npm run dev
+```
+
+- [ ] **Step 2: Verify Play Again keeps players**
+
+Add 2–3 players. Enter scores until someone hits 200+. When the winner banner appears, click "Play Again". Expected: banner dismisses, players are still listed, all scores are cleared, round resets to Round 1.
+
+- [ ] **Step 3: Verify header New Game still wipes everything**
+
+With players listed from the previous step, click "New Game" in the header and confirm. Expected: all players and scores are cleared.
+
+- [ ] **Step 4: Verify localStorage**
+
+After clicking "Play Again", open browser DevTools → Application → localStorage. Expected: the stored state has players present but empty scores arrays.
+
+- [ ] **Step 5: Stop dev server**
+
+`Ctrl+C`
+
+---
+
+### Task 5: Create PR
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push -u origin feat/persist-players-on-new-game
+```
+
+- [ ] **Step 2: Create PR via MCP GitHub tool**
+
+Use `mcp__plugin_github_github__create_pull_request` with:
+- `owner`: `nickjharr`
+- `repo`: `flip7scorecard`
+- `title`: `feat: keep players when starting a new game from winner banner`
+- `head`: `feat/persist-players-on-new-game`
+- `base`: `master`
+- `body`:
+
+```
+## Summary
+- Adds a `playAgain()` store function that resets scores and round to 0 while preserving the player list
+- Winner banner "New Game" button renamed to "Play Again" and wired to the new function
+- Header "New Game" button is unchanged — still wipes everything including players
+
+## Test plan
+- [ ] Click "Play Again" on winner banner → players kept, scores cleared, round resets to 1
+- [ ] Click "New Game" in header → all players and scores wiped (existing behaviour)
+- [ ] localStorage after Play Again → players present, scores empty
+```

--- a/docs/superpowers/specs/2026-03-17-persist-players-on-new-game-design.md
+++ b/docs/superpowers/specs/2026-03-17-persist-players-on-new-game-design.md
@@ -36,6 +36,10 @@ export function playAgain(): void {
 
 This rebuilds `game.scores` with an empty array per existing player, resets `currentRound` to 0, and clears the Flip 7 banner. `game.players` is not touched.
 
+Note: `playAgain()` calls `persist()` rather than `localStorage.removeItem()` (as `newGame()` does). This is intentional — the goal is to save the reset state with the player list intact, not discard it.
+
+Note: the winner banner's visibility is controlled by the `winners` local state variable in `+page.svelte`, not by anything in the store. `playAgain()` does not need to touch `winners` — that is handled in `handlePlayAgain()` in `+page.svelte`.
+
 ### Changes to `src/routes/+page.svelte`
 
 1. **Import `playAgain`** from `$lib/game.svelte`.
@@ -46,9 +50,12 @@ This rebuilds `game.scores` with an empty array per existing player, resets `cur
 function handlePlayAgain() {
   playAgain();
   winners = null;
+  showNewGameConfirm = false;
   expandedPlayerId = null;
 }
 ```
+
+`winners = null` dismisses the winner banner. `showNewGameConfirm = false` is included defensively for consistency with `handleNewGame()`, even though both dialogs cannot be simultaneously visible in practice.
 
 3. **Update the winner banner button:**
 
@@ -67,3 +74,4 @@ Change the button label from "New Game" to "Play Again" and wire `onclick` to `h
 | Game ends, user clicks "Play Again" | Scores and round reset to 0; players kept; winner banner dismissed |
 | Header "New Game" clicked at any time | All players, scores, and round wiped (existing behaviour unchanged) |
 | localStorage after Play Again | Persisted state reflects reset scores and round with players intact |
+| `playAgain()` called with no players | No-op for scores loop; round resets to 0; safe — call site guarantees players exist |

--- a/docs/superpowers/specs/2026-03-17-persist-players-on-new-game-design.md
+++ b/docs/superpowers/specs/2026-03-17-persist-players-on-new-game-design.md
@@ -1,0 +1,69 @@
+# Design: Persist Players on New Game
+
+**Date:** 2026-03-17
+**Status:** Draft
+
+## Problem
+
+When a game ends (a winner is declared), the winner banner offers a "New Game" button that wipes all players and scores. Players who want a rematch must re-enter every player name manually.
+
+## Solution
+
+Rename the winner banner button to "Play Again" and wire it to a new `playAgain()` action that resets scores and round number but keeps the player list intact. The header "New Game" button continues to wipe everything.
+
+## Design
+
+### Approach
+
+Option A — add a `playAgain()` function to `game.svelte.ts` and update the winner banner in `+page.svelte`. No changes to `newGame()` or `gameLogic.ts`.
+
+### Changes to `src/lib/game.svelte.ts`
+
+Add a new exported function:
+
+```ts
+export function playAgain(): void {
+  const freshScores: Record<string, (number | null)[]> = {};
+  for (const player of game.players) {
+    freshScores[player.id] = [];
+  }
+  game.scores = freshScores;
+  game.currentRound = 0;
+  flip7Banner.active = false;
+  persist();
+}
+```
+
+This rebuilds `game.scores` with an empty array per existing player, resets `currentRound` to 0, and clears the Flip 7 banner. `game.players` is not touched.
+
+### Changes to `src/routes/+page.svelte`
+
+1. **Import `playAgain`** from `$lib/game.svelte`.
+
+2. **Add `handlePlayAgain()` handler:**
+
+```ts
+function handlePlayAgain() {
+  playAgain();
+  winners = null;
+  expandedPlayerId = null;
+}
+```
+
+3. **Update the winner banner button:**
+
+Change the button label from "New Game" to "Play Again" and wire `onclick` to `handlePlayAgain()` instead of `handleNewGame()`.
+
+### No changes to
+
+- `src/lib/gameLogic.ts`
+- The header "New Game" button (`handleNewGame()` still calls `newGame()`)
+- Any other component
+
+## Behaviour
+
+| Scenario | Result |
+|----------|--------|
+| Game ends, user clicks "Play Again" | Scores and round reset to 0; players kept; winner banner dismissed |
+| Header "New Game" clicked at any time | All players, scores, and round wiped (existing behaviour unchanged) |
+| localStorage after Play Again | Persisted state reflects reset scores and round with players intact |

--- a/src/lib/game.svelte.ts
+++ b/src/lib/game.svelte.ts
@@ -102,5 +102,16 @@ export function newGame(): void {
   }
 }
 
+export function playAgain(): void {
+  const freshScores: Record<string, (number | null)[]> = {};
+  for (const player of game.players) {
+    freshScores[player.id] = [];
+  }
+  game.scores = freshScores;
+  game.currentRound = 0;
+  flip7Banner.active = false;
+  persist();
+}
+
 // Re-export derived helpers for convenience in components.
 export { totalScore, getWinners };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { game, addPlayer, endRound, newGame, getWinners, totalScore, flip7Banner } from '$lib/game.svelte';
+  import { game, addPlayer, endRound, newGame, playAgain, getWinners, totalScore, flip7Banner } from '$lib/game.svelte';
   import PlayerRow from '$lib/components/PlayerRow.svelte';
   import HelpModal from '$lib/components/HelpModal.svelte';
 
@@ -50,6 +50,13 @@
     winners = null;
     showNewGameConfirm = false;
     expandedPlayerId = null;
+  }
+
+  function handlePlayAgain() {
+    winners = null;
+    showNewGameConfirm = false;
+    expandedPlayerId = null;
+    playAgain();
   }
 
   // End Round is enabled when: ≥1 player exists AND ≥1 score entered this round
@@ -242,10 +249,10 @@
         {winners[0] ? totalScore(game.scores, winners[0].id) : 0} points
       </p>
       <button
-        onclick={handleNewGame}
+        onclick={handlePlayAgain}
         class="w-full py-3 rounded-xl bg-blue-600 hover:bg-blue-500 font-semibold transition-colors"
       >
-        New Game
+        Play Again
       </button>
     </div>
   </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -46,10 +46,10 @@
   }
 
   function handleNewGame() {
-    newGame();
     winners = null;
     showNewGameConfirm = false;
     expandedPlayerId = null;
+    newGame();
   }
 
   function handlePlayAgain() {


### PR DESCRIPTION
## Summary
- Adds a `playAgain()` store function that resets scores and round to 0 while preserving the player list
- Winner banner "New Game" button renamed to "Play Again" and wired to the new function
- Header "New Game" button is unchanged — still wipes everything including players
- Also fixes operation ordering in both `handlePlayAgain` and `handleNewGame` so `winners` is cleared before store state is reset (prevents a score flicker on the winner banner)

## Test plan
- [ ] Click "Play Again" on winner banner → players kept, scores cleared, round resets to 1
- [ ] Click "New Game" in header → all players and scores wiped (existing behaviour)
- [ ] localStorage after Play Again → players present, scores empty
