### PR TITLE
feat: swipe-to-remove player rows and fix long-press gesture

### DIFF
--- a/docs/superpowers/plans/2026-03-17-swipe-to-remove-player.md
+++ b/docs/superpowers/plans/2026-03-17-swipe-to-remove-player.md
@@ -1,0 +1,428 @@
+# Swipe to Remove Player Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add swipe-left-to-remove on player rows and fix the broken long-press gesture to make the rename/remove action sheet reachable on mobile.
+
+**Architecture:** All changes are confined to `src/lib/components/PlayerRow.svelte`. The existing `removePlayer()`/`renamePlayer()` store functions and the action sheet markup are untouched — only the gesture detection and DOM layout change. A red 🗑️ strip sits behind each row; swiping left reveals it. Long-press is fixed by replacing `oncontextmenu` with a proper 500ms touch timer.
+
+**Tech Stack:** SvelteKit 2, Svelte 5 runes (`$state`, `$effect`), TypeScript, Tailwind CSS v4
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `src/lib/components/PlayerRow.svelte` | New state, restructured DOM layout, swipe + long-press touch handlers |
+
+---
+
+### Task 1: Create feature branch
+
+- [ ] **Step 1: Create and switch to feature branch**
+
+```bash
+git checkout -b feat/swipe-to-remove-player
+```
+
+Expected: `Switched to a new branch 'feat/swipe-to-remove-player'`
+
+---
+
+### Task 2: Add new state variables
+
+**Files:**
+- Modify: `src/lib/components/PlayerRow.svelte` (script block)
+
+The current script block declares `showActions`, `isRenaming`, `renameValue`, and derived values. Add the new variables below the existing `let showActions = $state(false)` line.
+
+- [ ] **Step 1: Add swipe and long-press state**
+
+```ts
+// Swipe-to-remove state
+let swipeOffset = $state(0);        // current translateX px, range 0 to -72
+let swipeLocked = $state(false);    // true when row is snapped open at -72px
+let touchStartX = 0;                // plain vars — no reactive binding needed
+let touchStartY = 0;
+let isSwipeGesture = false;
+let rowContentEl: HTMLDivElement;
+let longPressTimer: ReturnType<typeof setTimeout> | null = null;
+```
+
+- [ ] **Step 2: Run type check**
+
+```bash
+npm run check
+```
+
+Expected: 0 errors, 0 warnings.
+
+---
+
+### Task 3: Restructure the row DOM layout
+
+**Files:**
+- Modify: `src/lib/components/PlayerRow.svelte` (template)
+
+The current outer div wraps the button and expanded panel directly. We need to:
+1. Add `relative overflow-hidden` to the outer div (it already has `rounded-lg`)
+2. Insert the red strip as an absolutely-positioned child
+3. Wrap the button + expanded panel in a new `bind:this` inner div
+
+- [ ] **Step 1: Add `score-history` class to the history div**
+
+Find this line in the template (currently around line 95):
+
+```svelte
+<div class="flex flex-nowrap overflow-x-auto mt-0.5">
+```
+
+Change it to:
+
+```svelte
+<div class="score-history flex flex-nowrap overflow-x-auto mt-0.5">
+```
+
+This class is required for touch conflict detection (skip swipe tracking when touch starts in score history).
+
+- [ ] **Step 2: Restructure the outer div and add the inner sliding wrapper**
+
+Replace the entire row container block:
+
+```svelte
+<!-- Row container -->
+<div class="border-b border-gray-800 last:border-0 rounded-lg transition-all duration-300 mb-3" style={rowGlowStyle}>
+
+  <!-- Main row (tap to expand) -->
+  <button
+    class="w-full flex items-center gap-3 px-3 py-3 text-left"
+    onclick={onExpand}
+    oncontextmenu={(e) => { e.preventDefault(); handleLongPress(); }}
+  >
+```
+
+With:
+
+```svelte
+<!-- Row container — relative+overflow-hidden required for swipe reveal -->
+<div class="relative overflow-hidden border-b border-gray-800 last:border-0 rounded-lg transition-all duration-300 mb-3" style={rowGlowStyle}>
+
+  <!-- Red remove strip — sits behind the sliding content -->
+  <div class="absolute inset-y-0 right-0 w-[72px] bg-red-600 flex items-center justify-center text-xl"
+       role="button"
+       tabindex="-1"
+       aria-label="Remove {player.name}"
+       onclick={handleRemove}
+       onkeydown={(e) => e.key === 'Enter' && handleRemove()}>
+    🗑️
+  </div>
+
+  <!-- Inner sliding content -->
+  <div
+    bind:this={rowContentEl}
+    ontouchstart={handleTouchStart}
+    ontouchend={handleTouchEnd}
+    onclick={handleContentClick}
+    style="transform: translateX({swipeOffset}px); transition: {isSwipeGesture ? 'none' : 'transform 150ms ease'}"
+  >
+
+  <!-- Main row (tap to expand) -->
+  <button
+    class="w-full flex items-center gap-3 px-3 py-3 text-left"
+    onclick={onExpand}
+    ontouchstart={handleRowTouchStart}
+    ontouchend={cancelLongPress}
+    oncontextmenu={(e) => { e.preventDefault(); handleLongPress(); }}
+  >
+```
+
+- [ ] **Step 3: Close the new inner div before closing the outer div**
+
+Find the closing tags at the bottom of the template (currently around line 124–126):
+
+```svelte
+  <!-- Expanded: inline score input -->
+  {#if isExpanded}
+    <div class="px-3 pb-3">
+      <ScoreInput {player} {currentRoundScore} onSave={onExpand} />
+    </div>
+  {/if}
+
+</div>
+```
+
+Change to:
+
+```svelte
+  <!-- Expanded: inline score input -->
+  {#if isExpanded}
+    <div class="px-3 pb-3">
+      <ScoreInput {player} {currentRoundScore} onSave={onExpand} />
+    </div>
+  {/if}
+
+  </div> <!-- end inner sliding content -->
+</div>   <!-- end outer row container -->
+```
+
+- [ ] **Step 4: Run type check**
+
+```bash
+npm run check
+```
+
+Expected: 0 errors, 0 warnings.
+
+---
+
+### Task 4: Add swipe touch handlers
+
+**Files:**
+- Modify: `src/lib/components/PlayerRow.svelte` (script block)
+
+Add these functions in the script block, after the existing `handleRemove()` function.
+
+- [ ] **Step 1: Add `handleTouchStart`, `handleTouchMove`, `handleTouchEnd`, `handleContentClick`**
+
+```ts
+function handleTouchStart(e: TouchEvent) {
+  // Always reset gesture state, even if we bail early
+  isSwipeGesture = false;
+
+  // If touch starts inside score history, skip swipe tracking — let it scroll
+  if ((e.target as Element).closest('.score-history')) return;
+
+  const t = e.touches[0];
+  touchStartX = t.clientX;
+  touchStartY = t.clientY;
+}
+
+function handleTouchMove(e: TouchEvent) {
+  const t = e.touches[0];
+  const deltaX = t.clientX - touchStartX;
+  const deltaY = t.clientY - touchStartY;
+
+  // Left swipe from unlocked state
+  if (!isSwipeGesture && !swipeLocked && Math.abs(deltaX) > Math.abs(deltaY) && deltaX < 0) {
+    isSwipeGesture = true;
+    clearTimeout(longPressTimer!);
+    longPressTimer = null;
+  }
+
+  // Right swipe from locked state — drag back to close
+  if (!isSwipeGesture && swipeLocked && Math.abs(deltaX) > Math.abs(deltaY) && deltaX > 0) {
+    isSwipeGesture = true;
+    clearTimeout(longPressTimer!);
+    longPressTimer = null;
+  }
+
+  if (isSwipeGesture) {
+    e.preventDefault(); // works because listener is registered with { passive: false }
+    if (swipeLocked) {
+      swipeOffset = Math.min(0, -72 + deltaX);
+    } else {
+      swipeOffset = Math.max(-72, Math.min(0, deltaX));
+    }
+  }
+}
+
+function handleTouchEnd() {
+  if (!isSwipeGesture) return;
+  if (swipeLocked) {
+    // Was dragging right to close — commit if past threshold
+    if (swipeOffset > -40) {
+      swipeOffset = 0;
+      swipeLocked = false;
+    } else {
+      swipeOffset = -72; // snap back open
+    }
+  } else {
+    // Was dragging left to open — commit if past threshold
+    if (swipeOffset < -40) {
+      swipeOffset = -72;
+      swipeLocked = true;
+    } else {
+      swipeOffset = 0;
+    }
+  }
+  isSwipeGesture = false;
+}
+
+function handleContentClick(e: MouseEvent) {
+  // When locked open, any tap on the content snaps back (does not expand/collapse)
+  if (swipeLocked) {
+    e.stopPropagation();
+    swipeOffset = 0;
+    swipeLocked = false;
+  }
+}
+```
+
+- [ ] **Step 2: Add the passive-false `$effect` for `handleTouchMove`**
+
+After the existing `$derived` blocks (around line 43), add:
+
+```ts
+// Must be registered with { passive: false } to allow e.preventDefault() during swipe
+$effect(() => {
+  if (!rowContentEl) return;
+  rowContentEl.addEventListener('touchmove', handleTouchMove, { passive: false });
+  return () => rowContentEl.removeEventListener('touchmove', handleTouchMove);
+});
+```
+
+- [ ] **Step 3: Add the swipe-state reset `$effect`**
+
+```ts
+// Reset swipe state when rename input or action sheet opens
+$effect(() => {
+  if (isRenaming || showActions) {
+    swipeOffset = 0;
+    swipeLocked = false;
+  }
+});
+```
+
+- [ ] **Step 4: Run type check**
+
+```bash
+npm run check
+```
+
+Expected: 0 errors, 0 warnings.
+
+---
+
+### Task 5: Add long-press touch handlers
+
+**Files:**
+- Modify: `src/lib/components/PlayerRow.svelte` (script block)
+
+The existing `handleLongPress()` function (sets `showActions = true`) stays — we just need to add the timer-based touch handlers that call it.
+
+- [ ] **Step 1: Add `handleRowTouchStart` and `cancelLongPress`**
+
+```ts
+function handleRowTouchStart() {
+  longPressTimer = setTimeout(() => {
+    showActions = true;
+    longPressTimer = null;
+  }, 500);
+}
+
+function cancelLongPress() {
+  if (longPressTimer) {
+    clearTimeout(longPressTimer);
+    longPressTimer = null;
+  }
+}
+```
+
+These are already wired to the `<button>` via `ontouchstart={handleRowTouchStart}` and `ontouchend={cancelLongPress}` from Task 3. The existing `oncontextmenu` handler is also already in place from Task 3.
+
+- [ ] **Step 2: Run type check**
+
+```bash
+npm run check
+```
+
+Expected: 0 errors, 0 warnings.
+
+- [ ] **Step 3: Run lint**
+
+```bash
+npm run lint
+```
+
+Expected: No errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/components/PlayerRow.svelte
+git commit -m "feat: swipe-to-remove player rows and fix long-press gesture"
+```
+
+---
+
+### Task 6: Manual verification
+
+> Note: This is a gesture-based feature requiring a real device or browser DevTools touch simulation. Use Chrome DevTools → Toggle device toolbar (Ctrl+Shift+M) to simulate touch events.
+
+- [ ] **Step 1: Start dev server**
+
+```bash
+npm run dev
+```
+
+- [ ] **Step 2: Verify swipe-to-remove**
+
+Add 2 players. In DevTools touch mode, swipe a row left past halfway. Expected: row snaps open at 72px revealing 🗑️. Tap 🗑️. Expected: player removed from list.
+
+- [ ] **Step 3: Verify snap-back on short swipe**
+
+Swipe a row left less than halfway, release. Expected: row snaps back to 0, no remove action.
+
+- [ ] **Step 4: Verify tap-to-close when locked open**
+
+Swipe a row open (locked). Tap on the row content area. Expected: row snaps back, expand/collapse does not trigger.
+
+- [ ] **Step 5: Verify right-swipe to close**
+
+Swipe a row open (locked). Swipe right past 32px. Expected: row snaps back to 0.
+
+- [ ] **Step 6: Verify score history scroll is unaffected**
+
+Play several rounds so the score history has entries. Touch and scroll the score history area horizontally. Expected: scrolls normally without triggering swipe.
+
+- [ ] **Step 7: Verify long-press opens action sheet**
+
+Long-press (hold) a row for 500ms. Expected: action sheet appears with "Rename" and "Remove".
+
+- [ ] **Step 8: Verify right-click still works on desktop**
+
+In non-touch mode, right-click a player row. Expected: action sheet appears.
+
+- [ ] **Step 9: Stop dev server**
+
+`Ctrl+C`
+
+---
+
+### Task 7: Create PR
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push -u origin feat/swipe-to-remove-player
+```
+
+- [ ] **Step 2: Create PR via MCP GitHub tool**
+
+Use `mcp__plugin_github_github__create_pull_request` with:
+- `owner`: `nickjharr`
+- `repo`: `flip7scorecard`
+- `title`: `feat: swipe-to-remove player rows and fix long-press gesture`
+- `head`: `feat/swipe-to-remove-player`
+- `base`: `master`
+- `body`:
+
+```
+## Summary
+- Swipe a player row left to reveal a red 🗑️ strip; tap it to remove the player
+- Swipe < halfway snaps back; swipe > halfway locks open; swipe right to close
+- Score history horizontal scroll is unaffected (conflict detection via `.score-history` class)
+- Fixes the broken long-press gesture — replaced `oncontextmenu`-only trigger with a proper 500ms touch timer
+- Right-click on desktop still opens the action sheet (existing behaviour preserved)
+
+## Test plan
+- [ ] Swipe left > 40px → row locks open at 72px, 🗑️ visible
+- [ ] Swipe left < 40px → row snaps back, no action
+- [ ] Tap 🗑️ → player removed
+- [ ] Tap row content while locked → snaps back, no expand
+- [ ] Swipe right > 32px while locked → snaps back to closed
+- [ ] Score history touch → scrolls normally, no swipe triggered
+- [ ] Long-press 500ms → action sheet opens (Rename / Remove)
+- [ ] Right-click desktop → action sheet opens
+```

--- a/docs/superpowers/specs/2026-03-17-swipe-to-remove-player-design.md
+++ b/docs/superpowers/specs/2026-03-17-swipe-to-remove-player-design.md
@@ -1,0 +1,115 @@
+# Design: Swipe to Remove Player
+
+**Date:** 2026-03-17
+**Status:** Draft
+
+## Problem
+
+Players cannot be removed from the game without restarting. A remove action exists in `PlayerRow.svelte` (via `removePlayer()`) and an action sheet with Rename/Remove buttons is implemented, but it is only triggered by `oncontextmenu` — right-click on desktop, unreliable on mobile. The feature is effectively inaccessible on the primary target platform.
+
+## Solution
+
+Two complementary gestures, both in `PlayerRow.svelte`:
+
+1. **Swipe left** to reveal a red 🗑️ strip — tap it to remove the player
+2. **Long-press** (fixed with proper touch events) to open the existing action sheet for rename/remove
+
+## Design
+
+### All changes in `src/lib/components/PlayerRow.svelte`
+
+No changes to `game.svelte.ts`, `gameLogic.ts`, or any other file. `removePlayer()` and `renamePlayer()` are already exported from the store.
+
+---
+
+### Swipe-to-remove
+
+**New state:**
+
+```ts
+let swipeOffset = $state(0);   // current translate X (0 to -72)
+let swipeLocked = $state(false); // true when snapped open
+let touchStartX = $state(0);
+let touchStartY = $state(0);
+let isSwipeGesture = $state(false);
+```
+
+**Layout change:**
+
+Wrap the existing row content in a relative container. Place the red remove strip absolutely behind it:
+
+```svelte
+<div class="relative overflow-hidden rounded-lg">
+  <!-- Red strip behind -->
+  <div class="absolute inset-y-0 right-0 w-18 bg-red-600 flex items-center justify-center text-xl"
+       onclick={handleRemove}>
+    🗑️
+  </div>
+  <!-- Row content slides over it -->
+  <div style="transform: translateX({swipeOffset}px); transition: {isSwipeGesture ? 'none' : 'transform 150ms ease'}">
+    <!-- existing row markup -->
+  </div>
+</div>
+```
+
+**Touch handlers on the row content div:**
+
+- `ontouchstart`: record `touchStartX`, `touchStartY`; set `isSwipeGesture = false`; check if target is inside the score history element — if so, bail out (let scroll happen)
+- `ontouchmove`: compute `deltaX` and `deltaY`; if `Math.abs(deltaX) > Math.abs(deltaY)` and `deltaX < 0`, set `isSwipeGesture = true` and clamp `swipeOffset = Math.max(-72, Math.min(0, deltaX))`; call `e.preventDefault()` to block page scroll during swipe
+- `ontouchend`: if `isSwipeGesture`:
+  - if `swipeOffset < -40`: snap to locked open (`swipeOffset = -72`, `swipeLocked = true`)
+  - else: snap back (`swipeOffset = 0`, `swipeLocked = false`)
+
+**Dismiss when locked open:**
+
+Tapping anywhere on the row content (not the 🗑️ strip) while `swipeLocked` snaps back. Add an `onclick` guard: if `swipeLocked`, call `e.stopPropagation()`, snap back, and return early.
+
+**Conflict with score history scroll:**
+
+The score history element gets a class `score-history`. On `touchstart`, check `(e.target as Element).closest('.score-history')` — if truthy, skip swipe tracking entirely.
+
+---
+
+### Long-press fix
+
+Replace `oncontextmenu` with a proper timer-based long-press:
+
+**New state:**
+
+```ts
+let longPressTimer: ReturnType<typeof setTimeout> | null = null;
+```
+
+**On the main row button:**
+
+Remove `oncontextmenu`. Add:
+
+- `ontouchstart`: start `longPressTimer = setTimeout(() => { showActions = true; }, 500)`
+- `ontouchend`: `clearTimeout(longPressTimer)`
+- `ontouchmove`: `clearTimeout(longPressTimer)` (movement cancels long-press)
+- Keep `oncontextmenu` as a secondary desktop trigger (right-click still works)
+
+**Coordination:** If a swipe gesture is detected (`isSwipeGesture = true`), clear the long-press timer to avoid both triggering simultaneously.
+
+---
+
+### No changes to
+
+- `src/lib/game.svelte.ts`
+- `src/lib/gameLogic.ts`
+- `src/routes/+page.svelte`
+- `src/lib/components/ScoreInput.svelte`
+
+## Behaviour
+
+| Scenario | Result |
+|----------|--------|
+| Swipe left < 40px then release | Row snaps back, no action |
+| Swipe left > 40px then release | Row locks open at 72px, 🗑️ visible |
+| Tap 🗑️ | Player removed immediately |
+| Tap row content while locked open | Row snaps back, no action taken |
+| Touch starts in score history area | Swipe tracking skipped; score history scrolls normally |
+| Long-press (500ms) on row | Action sheet opens with Rename and Remove buttons |
+| Release before 500ms | Long-press cancelled |
+| Move finger before 500ms | Long-press cancelled |
+| Right-click on desktop | Action sheet opens (existing behaviour preserved) |

--- a/docs/superpowers/specs/2026-03-17-swipe-to-remove-player-design.md
+++ b/docs/superpowers/specs/2026-03-17-swipe-to-remove-player-design.md
@@ -5,7 +5,7 @@
 
 ## Problem
 
-Players cannot be removed from the game without restarting. A remove action exists in `PlayerRow.svelte` (via `removePlayer()`) and an action sheet with Rename/Remove buttons is implemented, but it is only triggered by `oncontextmenu` — right-click on desktop, unreliable on mobile. The feature is effectively inaccessible on the primary target platform.
+Players cannot be removed mid-game. `removePlayer()` is exported from the store and called from an action sheet in `PlayerRow.svelte`, but the action sheet has no working mobile trigger. The only trigger is `oncontextmenu`, which fires on right-click (desktop) but does not reliably fire on touch long-press across iOS and Android browsers. There is no working mobile path to the remove action.
 
 ## Solution
 
@@ -22,74 +22,212 @@ No changes to `game.svelte.ts`, `gameLogic.ts`, or any other file. `removePlayer
 
 ---
 
+### DOM structure (new layout)
+
+The row gains an outer wrapper for the swipe effect. The red strip sits behind the row content:
+
+```
+<div class="relative overflow-hidden rounded-lg mb-3 ...">  ← outer wrapper (swipe container)
+  <div class="absolute inset-y-0 right-0 w-[72px] ...">    ← red strip (always present, behind)
+    🗑️ button
+  </div>
+  <div bind:this={rowContentEl}                             ← inner content (slides)
+       ontouchstart={handleTouchStart}
+       ontouchend={handleTouchEnd}
+       onclick={handleContentClick}
+       style="transform: translateX(...)">
+    <button ontouchstart={handleRowTouchStart}              ← main row button (long-press + tap)
+            ontouchend={cancelLongPress}
+            oncontextmenu={...}>
+      ... existing row markup ...
+    </button>
+    {#if isExpanded} score input {/if}
+  </div>
+</div>
+```
+
+**Key points:**
+- Swipe handlers (`handleTouchStart`, `handleTouchEnd`) are on the **inner content div**, so they wrap both the collapsed row and the expanded score panel
+- `handleTouchMove` is attached via `$effect` with `{ passive: false }` on the same div (see below)
+- Long-press handlers (`handleRowTouchStart`, `cancelLongPress`) are on the **`<button>`** inside the content div
+- `handleContentClick` on the inner div snaps the row back when tapped while locked open
+- `bind:this={rowContentEl}` is used to attach the passive:false touchmove listener
+
+---
+
 ### Swipe-to-remove
 
 **New state:**
 
 ```ts
-let swipeOffset = $state(0);   // current translate X (0 to -72)
-let swipeLocked = $state(false); // true when snapped open
-let touchStartX = $state(0);
-let touchStartY = $state(0);
-let isSwipeGesture = $state(false);
+let swipeOffset = $state(0);        // current translateX, range 0 to -72
+let swipeLocked = $state(false);    // true when snapped open at -72
+let touchStartX = 0;                // plain variables (not reactive — no UI binding needed)
+let touchStartY = 0;
+let isSwipeGesture = false;
+let rowContentEl: HTMLDivElement;
+let longPressTimer: ReturnType<typeof setTimeout> | null = null;
 ```
 
-**Layout change:**
-
-Wrap the existing row content in a relative container. Place the red remove strip absolutely behind it:
+**Add `score-history` class to the history div** (required for conflict detection):
 
 ```svelte
-<div class="relative overflow-hidden rounded-lg">
-  <!-- Red strip behind -->
-  <div class="absolute inset-y-0 right-0 w-18 bg-red-600 flex items-center justify-center text-xl"
-       onclick={handleRemove}>
-    🗑️
-  </div>
-  <!-- Row content slides over it -->
-  <div style="transform: translateX({swipeOffset}px); transition: {isSwipeGesture ? 'none' : 'transform 150ms ease'}">
-    <!-- existing row markup -->
-  </div>
-</div>
+<!-- was: <div class="flex flex-nowrap overflow-x-auto mt-0.5"> -->
+<div class="score-history flex flex-nowrap overflow-x-auto mt-0.5">
 ```
 
-**Touch handlers on the row content div:**
+**Passive-false touchmove listener** (required to call `e.preventDefault()` — Svelte 5 event attributes are passive by default):
 
-- `ontouchstart`: record `touchStartX`, `touchStartY`; set `isSwipeGesture = false`; check if target is inside the score history element — if so, bail out (let scroll happen)
-- `ontouchmove`: compute `deltaX` and `deltaY`; if `Math.abs(deltaX) > Math.abs(deltaY)` and `deltaX < 0`, set `isSwipeGesture = true` and clamp `swipeOffset = Math.max(-72, Math.min(0, deltaX))`; call `e.preventDefault()` to block page scroll during swipe
-- `ontouchend`: if `isSwipeGesture`:
-  - if `swipeOffset < -40`: snap to locked open (`swipeOffset = -72`, `swipeLocked = true`)
-  - else: snap back (`swipeOffset = 0`, `swipeLocked = false`)
+```ts
+$effect(() => {
+  if (!rowContentEl) return;
+  rowContentEl.addEventListener('touchmove', handleTouchMove, { passive: false });
+  return () => rowContentEl.removeEventListener('touchmove', handleTouchMove);
+});
+```
 
-**Dismiss when locked open:**
+**Touch handlers:**
 
-Tapping anywhere on the row content (not the 🗑️ strip) while `swipeLocked` snaps back. Add an `onclick` guard: if `swipeLocked`, call `e.stopPropagation()`, snap back, and return early.
+```ts
+function handleTouchStart(e: TouchEvent) {
+  // Always reset gesture state, even if we bail early
+  isSwipeGesture = false;
 
-**Conflict with score history scroll:**
+  // If touch starts inside score history, skip swipe tracking — let it scroll
+  if ((e.target as Element).closest('.score-history')) return;
 
-The score history element gets a class `score-history`. On `touchstart`, check `(e.target as Element).closest('.score-history')` — if truthy, skip swipe tracking entirely.
+  const t = e.touches[0];
+  touchStartX = t.clientX;
+  touchStartY = t.clientY;
+}
+
+function handleTouchMove(e: TouchEvent) {
+  const t = e.touches[0];
+  const deltaX = t.clientX - touchStartX;
+  const deltaY = t.clientY - touchStartY;
+
+  // Left swipe from unlocked state
+  if (!isSwipeGesture && !swipeLocked && Math.abs(deltaX) > Math.abs(deltaY) && deltaX < 0) {
+    isSwipeGesture = true;
+    clearTimeout(longPressTimer!); // cancel long-press if swipe detected
+    longPressTimer = null;
+  }
+
+  // Right swipe from locked state — drag back to close
+  if (!isSwipeGesture && swipeLocked && Math.abs(deltaX) > Math.abs(deltaY) && deltaX > 0) {
+    isSwipeGesture = true;
+    clearTimeout(longPressTimer!);
+    longPressTimer = null;
+  }
+
+  if (isSwipeGesture) {
+    e.preventDefault(); // works because listener is { passive: false }
+    if (swipeLocked) {
+      // Dragging right from locked: offset starts at -72, moves toward 0
+      swipeOffset = Math.min(0, -72 + deltaX);
+    } else {
+      // Dragging left from closed: offset starts at 0, moves toward -72
+      swipeOffset = Math.max(-72, Math.min(0, deltaX));
+    }
+  }
+}
+
+function handleTouchEnd() {
+  if (!isSwipeGesture) return;
+  if (swipeLocked) {
+    // Was dragging right to close
+    if (swipeOffset > -40) {
+      swipeOffset = 0;
+      swipeLocked = false;
+    } else {
+      swipeOffset = -72; // snap back open
+    }
+  } else {
+    // Was dragging left to open
+    if (swipeOffset < -40) {
+      swipeOffset = -72;
+      swipeLocked = true;
+    } else {
+      swipeOffset = 0;
+    }
+  }
+  isSwipeGesture = false;
+}
+```
+
+**Snap back when tapping locked row:**
+
+On the inner content div, add an `onclick` guard:
+
+```ts
+function handleContentClick(e: MouseEvent) {
+  if (swipeLocked) {
+    e.stopPropagation();
+    swipeOffset = 0;
+    swipeLocked = false;
+    return;
+  }
+}
+```
+
+**Reset swipe state when rename or actions open** (prevents offset persisting into inline rename):
+
+```ts
+$effect(() => {
+  if (isRenaming || showActions) {
+    swipeOffset = 0;
+    swipeLocked = false;
+  }
+});
+```
 
 ---
 
 ### Long-press fix
 
-Replace `oncontextmenu` with a proper timer-based long-press:
-
-**New state:**
+Remove `oncontextmenu` from the `<button>` as the sole mobile trigger. Replace with a 500ms timer:
 
 ```ts
-let longPressTimer: ReturnType<typeof setTimeout> | null = null;
+function handleRowTouchStart(e: TouchEvent) {
+  longPressTimer = setTimeout(() => {
+    showActions = true;
+    longPressTimer = null;
+  }, 500);
+}
+
+function cancelLongPress() {
+  if (longPressTimer) {
+    clearTimeout(longPressTimer);
+    longPressTimer = null;
+  }
+}
 ```
 
-**On the main row button:**
+On the `<button>`:
 
-Remove `oncontextmenu`. Add:
+```svelte
+ontouchstart={handleRowTouchStart}
+ontouchend={cancelLongPress}
+oncontextmenu={(e) => { e.preventDefault(); handleLongPress(); }}
+```
 
-- `ontouchstart`: start `longPressTimer = setTimeout(() => { showActions = true; }, 500)`
-- `ontouchend`: `clearTimeout(longPressTimer)`
-- `ontouchmove`: `clearTimeout(longPressTimer)` (movement cancels long-press)
-- Keep `oncontextmenu` as a secondary desktop trigger (right-click still works)
+Note: `handleTouchMove` (on the outer content div) also calls `clearTimeout(longPressTimer)` when a swipe is detected, ensuring the two gestures never fire simultaneously.
 
-**Coordination:** If a swipe gesture is detected (`isSwipeGesture = true`), clear the long-press timer to avoid both triggering simultaneously.
+---
+
+### CSS transition
+
+Apply transition only when not actively dragging:
+
+```svelte
+style="transform: translateX({swipeOffset}px); transition: {isSwipeGesture ? 'none' : 'transform 150ms ease'}"
+```
+
+---
+
+### Tailwind width note
+
+Use `w-[72px]` (arbitrary value syntax) for the red strip width, not `w-18`, to ensure correct rendering regardless of the project's Tailwind v4 scale configuration.
 
 ---
 
@@ -104,12 +242,17 @@ Remove `oncontextmenu`. Add:
 
 | Scenario | Result |
 |----------|--------|
-| Swipe left < 40px then release | Row snaps back, no action |
+| Swipe left < 40px then release | Row snaps back to 0, no action |
 | Swipe left > 40px then release | Row locks open at 72px, 🗑️ visible |
+| Swipe right > 32px while row is locked open | Row snaps back to 0 |
+| Swipe right < 32px while row is locked open | Row snaps back open (stays at 72px) |
 | Tap 🗑️ | Player removed immediately |
-| Tap row content while locked open | Row snaps back, no action taken |
+| Tap row content while locked open | Row snaps back, expand/collapse does not trigger |
 | Touch starts in score history area | Swipe tracking skipped; score history scrolls normally |
-| Long-press (500ms) on row | Action sheet opens with Rename and Remove buttons |
-| Release before 500ms | Long-press cancelled |
-| Move finger before 500ms | Long-press cancelled |
+| Long-press 500ms on row | Action sheet opens with Rename and Remove |
+| Release or move before 500ms | Long-press cancelled |
+| Swipe detected (any distance) | Long-press timer cancelled immediately |
+| `isRenaming` becomes true (from action sheet) | `swipeOffset` and `swipeLocked` reset to 0/false |
+| `showActions` becomes true | `swipeOffset` and `swipeLocked` reset to 0/false |
 | Right-click on desktop | Action sheet opens (existing behaviour preserved) |
+| Multi-touch | Only `e.touches[0]` tracked; additional fingers ignored |

--- a/src/lib/components/PlayerRow.svelte
+++ b/src/lib/components/PlayerRow.svelte
@@ -43,12 +43,21 @@
   // Score for the current round
   const currentRoundScore = $derived(scores[currentRound] ?? null);
 
+  // Box-shadow on outer div (clips to rounded corners); background on inner div
   const rowGlowStyle = $derived(
     currentRoundScore === null
       ? ''
       : currentRoundScore > 0
-        ? 'box-shadow: 0 0 0 2px #16a34a, 0 0 12px rgba(22,163,74,0.4); background: #1a2e22'
-        : 'box-shadow: 0 0 0 2px #dc2626, 0 0 12px rgba(220,38,38,0.4); background: #2a1a1a'
+        ? 'box-shadow: 0 0 0 2px #16a34a, 0 0 12px rgba(22,163,74,0.4)'
+        : 'box-shadow: 0 0 0 2px #dc2626, 0 0 12px rgba(220,38,38,0.4)'
+  );
+
+  const rowBgStyle = $derived(
+    currentRoundScore === null
+      ? ''
+      : currentRoundScore > 0
+        ? 'background: #1a2e22'
+        : 'background: #2a1a1a'
   );
 
   function handleLongPress() {
@@ -72,7 +81,7 @@
     showActions = false;
   }
 
-  function handleTouchStart(e: TouchEvent) {
+  function handlePointerDown(e: PointerEvent) {
     // Always reset gesture state, even if we bail early
     isSwipeGesture = false;
 
@@ -83,18 +92,15 @@
       return;
     }
 
-    // Cancel any pending long-press — a swipe gesture is starting
-    cancelLongPress();
-
-    const t = e.touches[0];
-    touchStartX = t.clientX;
-    touchStartY = t.clientY;
+    touchStartX = e.clientX;
+    touchStartY = e.clientY;
+    // Capture pointer so pointermove fires even when cursor/finger leaves the element
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
   }
 
-  function handleTouchMove(e: TouchEvent) {
-    const t = e.touches[0];
-    const deltaX = t.clientX - touchStartX;
-    const deltaY = t.clientY - touchStartY;
+  function handlePointerMove(e: PointerEvent) {
+    const deltaX = e.clientX - touchStartX;
+    const deltaY = e.clientY - touchStartY;
 
     // Left swipe from unlocked state
     if (!isSwipeGesture && !swipeLocked && Math.abs(deltaX) > Math.abs(deltaY) && deltaX < 0) {
@@ -118,7 +124,7 @@
     }
   }
 
-  function handleTouchEnd() {
+  function handlePointerUp() {
     if (!isSwipeGesture) return;
     if (swipeLocked) {
       if (swipeOffset > -40) {
@@ -163,8 +169,8 @@
   // Must be registered with { passive: false } to allow e.preventDefault() during swipe
   $effect(() => {
     if (!rowContentEl) return;
-    rowContentEl.addEventListener('touchmove', handleTouchMove, { passive: false });
-    return () => rowContentEl.removeEventListener('touchmove', handleTouchMove);
+    rowContentEl.addEventListener('pointermove', handlePointerMove, { passive: false });
+    return () => rowContentEl.removeEventListener('pointermove', handlePointerMove);
   });
 
   // Reset swipe state when rename input or action sheet opens
@@ -189,22 +195,23 @@
     🗑️
   </div>
 
-  <!-- Inner sliding content — role=presentation: structural wrapper, not interactive -->
+  <!-- Inner sliding content — bg-gray-950 prevents red strip showing through -->
   <div
     role="presentation"
     bind:this={rowContentEl}
-    ontouchstart={handleTouchStart}
-    ontouchend={handleTouchEnd}
+    onpointerdown={handlePointerDown}
+    onpointerup={handlePointerUp}
     onclick={handleContentClick}
-    style="transform: translateX({swipeOffset}px); transition: {isSwipeGesture ? 'none' : 'transform 150ms ease'}"
+    class="bg-gray-950"
+    style="transform: translateX({swipeOffset}px); transition: {isSwipeGesture ? 'none' : 'transform 150ms ease'}; {rowBgStyle}"
   >
 
   <!-- Main row (tap to expand) -->
   <button
     class="w-full flex items-center gap-3 px-3 py-3 text-left"
     onclick={onExpand}
-    ontouchstart={handleRowTouchStart}
-    ontouchend={cancelLongPress}
+    onpointerdown={handleRowTouchStart}
+    onpointerup={cancelLongPress}
     oncontextmenu={(e) => { e.preventDefault(); handleLongPress(); }}
   >
     <!-- Player name + history -->

--- a/src/lib/components/PlayerRow.svelte
+++ b/src/lib/components/PlayerRow.svelte
@@ -81,10 +81,7 @@
     showActions = false;
   }
 
-  function handlePointerDown(e: PointerEvent) {
-    // Swipe gesture is touch-only — desktop uses right-click (oncontextmenu)
-    if (e.pointerType === 'mouse') return;
-
+  function handleTouchStart(e: TouchEvent) {
     // Always reset gesture state, even if we bail early
     isSwipeGesture = false;
 
@@ -95,15 +92,15 @@
       return;
     }
 
-    touchStartX = e.clientX;
-    touchStartY = e.clientY;
-    // Capture pointer so pointermove fires even when finger leaves the element
-    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    const t = e.touches[0];
+    touchStartX = t.clientX;
+    touchStartY = t.clientY;
   }
 
-  function handlePointerMove(e: PointerEvent) {
-    const deltaX = e.clientX - touchStartX;
-    const deltaY = e.clientY - touchStartY;
+  function handleTouchMove(e: TouchEvent) {
+    const t = e.touches[0];
+    const deltaX = t.clientX - touchStartX;
+    const deltaY = t.clientY - touchStartY;
 
     // Left swipe from unlocked state
     if (!isSwipeGesture && !swipeLocked && Math.abs(deltaX) > Math.abs(deltaY) && deltaX < 0) {
@@ -127,7 +124,7 @@
     }
   }
 
-  function handlePointerUp() {
+  function handleTouchEnd() {
     if (!isSwipeGesture) return;
     if (swipeLocked) {
       if (swipeOffset > -40) {
@@ -155,9 +152,7 @@
     }
   }
 
-  function handleRowTouchStart(e: PointerEvent) {
-    // Long-press is touch-only — desktop uses right-click (oncontextmenu)
-    if (e.pointerType === 'mouse') return;
+  function handleRowTouchStart() {
     longPressTimer = setTimeout(() => {
       showActions = true;
       longPressTimer = null;
@@ -174,8 +169,8 @@
   // Must be registered with { passive: false } to allow e.preventDefault() during swipe
   $effect(() => {
     if (!rowContentEl) return;
-    rowContentEl.addEventListener('pointermove', handlePointerMove, { passive: false });
-    return () => rowContentEl.removeEventListener('pointermove', handlePointerMove);
+    rowContentEl.addEventListener('touchmove', handleTouchMove, { passive: false });
+    return () => rowContentEl.removeEventListener('touchmove', handleTouchMove);
   });
 
   // Reset swipe state when rename input or action sheet opens
@@ -204,8 +199,8 @@
   <div
     role="presentation"
     bind:this={rowContentEl}
-    onpointerdown={handlePointerDown}
-    onpointerup={handlePointerUp}
+    ontouchstart={handleTouchStart}
+    ontouchend={handleTouchEnd}
     onclick={handleContentClick}
     class="bg-gray-950"
     style="transform: translateX({swipeOffset}px); transition: {isSwipeGesture ? 'none' : 'transform 150ms ease'}; {rowBgStyle}"
@@ -215,8 +210,8 @@
   <button
     class="w-full flex items-center gap-3 px-3 py-3 text-left"
     onclick={onExpand}
-    onpointerdown={handleRowTouchStart}
-    onpointerup={cancelLongPress}
+    ontouchstart={handleRowTouchStart}
+    ontouchend={cancelLongPress}
     oncontextmenu={(e) => { e.preventDefault(); handleLongPress(); }}
   >
     <!-- Player name + history -->

--- a/src/lib/components/PlayerRow.svelte
+++ b/src/lib/components/PlayerRow.svelte
@@ -82,6 +82,9 @@
   }
 
   function handlePointerDown(e: PointerEvent) {
+    // Swipe gesture is touch-only — desktop uses right-click (oncontextmenu)
+    if (e.pointerType === 'mouse') return;
+
     // Always reset gesture state, even if we bail early
     isSwipeGesture = false;
 
@@ -94,7 +97,7 @@
 
     touchStartX = e.clientX;
     touchStartY = e.clientY;
-    // Capture pointer so pointermove fires even when cursor/finger leaves the element
+    // Capture pointer so pointermove fires even when finger leaves the element
     (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
   }
 
@@ -152,7 +155,9 @@
     }
   }
 
-  function handleRowTouchStart() {
+  function handleRowTouchStart(e: PointerEvent) {
+    // Long-press is touch-only — desktop uses right-click (oncontextmenu)
+    if (e.pointerType === 'mouse') return;
     longPressTimer = setTimeout(() => {
       showActions = true;
       longPressTimer = null;

--- a/src/lib/components/PlayerRow.svelte
+++ b/src/lib/components/PlayerRow.svelte
@@ -24,6 +24,15 @@
   let isRenaming = $state(false);
   let renameValue = $state(untrack(() => player.name));
 
+  // Swipe-to-remove state
+  let swipeOffset = $state(0);        // current translateX px, range 0 to -72
+  let swipeLocked = $state(false);    // true when row is snapped open at -72px
+  let touchStartX = 0;                // plain vars — no reactive binding needed
+  let touchStartY = 0;
+  let isSwipeGesture = $state(false);
+  let rowContentEl: HTMLDivElement;
+  let longPressTimer: ReturnType<typeof setTimeout> | null = null;
+
   // Cumulative totals at the end of each previous round
   const cumulativeHistory = $derived(
     scores.slice(0, Math.max(0, currentRound - 1)).map((_, i) =>
@@ -62,15 +71,140 @@
     removePlayer(player.id);
     showActions = false;
   }
+
+  function handleTouchStart(e: TouchEvent) {
+    // Always reset gesture state, even if we bail early
+    isSwipeGesture = false;
+
+    // If touch starts inside score history, skip swipe tracking — let it scroll
+    if ((e.target as Element).closest('.score-history')) {
+      touchStartX = 0;
+      touchStartY = 0;
+      return;
+    }
+
+    // Cancel any pending long-press — a swipe gesture is starting
+    cancelLongPress();
+
+    const t = e.touches[0];
+    touchStartX = t.clientX;
+    touchStartY = t.clientY;
+  }
+
+  function handleTouchMove(e: TouchEvent) {
+    const t = e.touches[0];
+    const deltaX = t.clientX - touchStartX;
+    const deltaY = t.clientY - touchStartY;
+
+    // Left swipe from unlocked state
+    if (!isSwipeGesture && !swipeLocked && Math.abs(deltaX) > Math.abs(deltaY) && deltaX < 0) {
+      isSwipeGesture = true;
+      cancelLongPress();
+    }
+
+    // Right swipe from locked state — drag back to close
+    if (!isSwipeGesture && swipeLocked && Math.abs(deltaX) > Math.abs(deltaY) && deltaX > 0) {
+      isSwipeGesture = true;
+      cancelLongPress();
+    }
+
+    if (isSwipeGesture) {
+      e.preventDefault(); // works because listener is registered with { passive: false }
+      if (swipeLocked) {
+        swipeOffset = Math.min(0, -72 + deltaX);
+      } else {
+        swipeOffset = Math.max(-72, Math.min(0, deltaX));
+      }
+    }
+  }
+
+  function handleTouchEnd() {
+    if (!isSwipeGesture) return;
+    if (swipeLocked) {
+      if (swipeOffset > -40) {
+        swipeOffset = 0;
+        swipeLocked = false;
+      } else {
+        swipeOffset = -72;
+      }
+    } else {
+      if (swipeOffset < -40) {
+        swipeOffset = -72;
+        swipeLocked = true;
+      } else {
+        swipeOffset = 0;
+      }
+    }
+    isSwipeGesture = false;
+  }
+
+  function handleContentClick(e: MouseEvent) {
+    if (swipeLocked) {
+      e.stopPropagation();
+      swipeOffset = 0;
+      swipeLocked = false;
+    }
+  }
+
+  function handleRowTouchStart() {
+    longPressTimer = setTimeout(() => {
+      showActions = true;
+      longPressTimer = null;
+    }, 500);
+  }
+
+  function cancelLongPress() {
+    if (longPressTimer) {
+      clearTimeout(longPressTimer);
+      longPressTimer = null;
+    }
+  }
+
+  // Must be registered with { passive: false } to allow e.preventDefault() during swipe
+  $effect(() => {
+    if (!rowContentEl) return;
+    rowContentEl.addEventListener('touchmove', handleTouchMove, { passive: false });
+    return () => rowContentEl.removeEventListener('touchmove', handleTouchMove);
+  });
+
+  // Reset swipe state when rename input or action sheet opens
+  $effect(() => {
+    if (isRenaming || showActions) {
+      swipeOffset = 0;
+      swipeLocked = false;
+    }
+  });
 </script>
 
-<!-- Row container -->
-<div class="border-b border-gray-800 last:border-0 rounded-lg transition-all duration-300 mb-3" style={rowGlowStyle}>
+<!-- Row container — relative+overflow-hidden required for swipe reveal -->
+<div class="relative overflow-hidden border-b border-gray-800 last:border-0 rounded-lg transition-all duration-300 mb-3" style={rowGlowStyle}>
+
+  <!-- Red remove strip — sits behind the sliding content -->
+  <div class="absolute inset-y-0 right-0 w-[72px] bg-red-600 flex items-center justify-center text-xl"
+       role="button"
+       tabindex="-1"
+       aria-label="Remove {player.name}"
+       onclick={handleRemove}
+       onkeydown={(e) => e.key === 'Enter' && handleRemove()}>
+    🗑️
+  </div>
+
+  <!-- Inner sliding content — role=presentation: structural wrapper, not interactive -->
+  <div
+    role="presentation"
+    bind:this={rowContentEl}
+    ontouchstart={handleTouchStart}
+    ontouchend={handleTouchEnd}
+    onclick={handleContentClick}
+    style="transform: translateX({swipeOffset}px); transition: {isSwipeGesture ? 'none' : 'transform 150ms ease'}"
+  >
 
   <!-- Main row (tap to expand) -->
   <button
     class="w-full flex items-center gap-3 px-3 py-3 text-left"
     onclick={onExpand}
+    ontouchstart={handleRowTouchStart}
+    ontouchend={cancelLongPress}
     oncontextmenu={(e) => { e.preventDefault(); handleLongPress(); }}
   >
     <!-- Player name + history -->
@@ -92,7 +226,7 @@
 
       <!-- Score history: cumulative total at end of each previous round -->
       {#if cumulativeHistory.length > 0}
-        <div class="flex flex-nowrap overflow-x-auto mt-0.5">
+        <div class="score-history flex flex-nowrap overflow-x-auto mt-0.5">
           {#each cumulativeHistory.slice(-9) as total, i (i)}
             <span class="w-9 shrink-0 text-xs text-gray-400 line-through text-center tabular-nums">
               {total}
@@ -123,7 +257,8 @@
     </div>
   {/if}
 
-</div>
+  </div> <!-- end inner sliding content -->
+</div>   <!-- end outer row container -->
 
 <!-- Actions overlay (rename / remove) -->
 {#if showActions}


### PR DESCRIPTION
## Summary
- Swipe a player row left to reveal a red 🗑️ strip; tap it to remove the player immediately
- Swipe > 40px locks open; swipe < 40px snaps back; swipe right to close
- Score history horizontal scroll is unaffected (touch in `.score-history` skips swipe tracking)
- Fixes the broken long-press gesture — `oncontextmenu` alone didn't work on mobile; replaced with a proper 500ms touch timer
- Long-press timer is cancelled immediately when a swipe gesture starts (prevents race condition on slow swipes)
- Right-click on desktop still opens the action sheet (existing behaviour preserved)

## Test plan
- [ ] Swipe left > 40px → row locks open at 72px, 🗑️ visible
- [ ] Swipe left < 40px → row snaps back, no action
- [ ] Tap 🗑️ → player removed
- [ ] Tap row content while locked → snaps back, expand/collapse does not trigger
- [ ] Swipe right > 32px while locked → row closes
- [ ] Score history touch → scrolls normally, no swipe triggered
- [ ] Long-press 500ms → action sheet opens (Rename / Remove)
- [ ] Right-click desktop → action sheet opens
