### PR TITLE
fix: restore CardCalculator full-screen overlay after swipe feature

### DIFF
--- a/src/lib/components/PlayerRow.svelte
+++ b/src/lib/components/PlayerRow.svelte
@@ -203,7 +203,7 @@
     ontouchend={handleTouchEnd}
     onclick={handleContentClick}
     class="bg-gray-950"
-    style="transform: translateX({swipeOffset}px); transition: {isSwipeGesture ? 'none' : 'transform 150ms ease'}; {rowBgStyle}"
+    style="{swipeOffset !== 0 ? `transform: translateX(${swipeOffset}px);` : ''} transition: {isSwipeGesture ? 'none' : 'transform 150ms ease'}; {rowBgStyle}"
   >
 
   <!-- Main row (tap to expand) -->

--- a/src/lib/components/PlayerRow.svelte
+++ b/src/lib/components/PlayerRow.svelte
@@ -202,7 +202,7 @@
     ontouchstart={handleTouchStart}
     ontouchend={handleTouchEnd}
     onclick={handleContentClick}
-    class="bg-gray-950"
+    class="relative bg-gray-950"
     style="{swipeOffset !== 0 ? `transform: translateX(${swipeOffset}px);` : ''} transition: {isSwipeGesture ? 'none' : 'transform 150ms ease'}; {rowBgStyle}"
   >
 


### PR DESCRIPTION
## Summary

- CSS transforms create a new containing block for `position: fixed` descendants (per CSS spec) — even `translateX(0px)` is not `none`
- The swipe-to-remove feature (PR #45) applied `transform: translateX({swipeOffset}px)` to the inner row div at all times, causing `CardCalculator`'s `fixed` positioning to be relative to the row element instead of the viewport
- Combined with `overflow: hidden` on the outer row container, the calculator was clipped inside the player card
- Fix: only apply the `transform` style when `swipeOffset !== 0` — at rest, no transform means fixed children position correctly; swipe gesture and snap-back animation are unaffected

## Test plan

- [ ] Open the app, add 2+ players, tap a player row to expand it
- [ ] Tap "🧮 Calc" — card calculator should slide up from the bottom overlaying the full screen
- [ ] Dismiss and verify swipe-to-remove still works (swipe left to reveal delete strip)
- [ ] Verify snap-back animation works on a partial swipe