### PR TITLE
fix: replace Play Again with Ok in winner modal

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -249,10 +249,10 @@
         {winners[0] ? totalScore(game.scores, winners[0].id) : 0} points
       </p>
       <button
-        onclick={handlePlayAgain}
+        onclick={() => (winners = null)}
         class="w-full py-3 rounded-xl bg-blue-600 hover:bg-blue-500 font-semibold transition-colors"
       >
-        Play Again
+        Ok
       </button>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Replaces the "Play Again" button in the winner modal with an "Ok" button that simply dismisses the modal
- Users can now view the final scoreboard after the game ends without being forced to start a new game
- A new game can still be started at any time via the "New Game" button in the header

## Test plan
- [ ] End a game (get a player to 200+ points) and verify the winner modal appears
- [ ] Tap "Ok" and confirm the modal dismisses, leaving the final scoreboard visible
- [ ] Verify the "New Game" button in the header still works to reset the game